### PR TITLE
Implement item completion route

### DIFF
--- a/README-MED-MNG.md
+++ b/README-MED-MNG.md
@@ -152,6 +152,13 @@ const song = await medMngApi.createSong(title, sunoAudioId, metadata);
 const streamUrl = medMngApi.getSongStreamUrl(songId);
 ```
 
+#### Nouveaux endpoints de vérification
+
+- `GET /verify-item/{id}` : retourne un rapport de complétude pour l'item ciblé.
+- `GET /verify-all` : liste les rapports pour tous les items enregistrés.
+- `POST /complete-item/{id}` : génère automatiquement le contenu manquant pour un item.
+- `POST /complete-all` : tente de compléter tous les items de la base.
+
 ## 🎵 Intégration Suno AI
 
 ### Génération musicale

--- a/supabase/functions/med-mng-api/index.ts
+++ b/supabase/functions/med-mng-api/index.ts
@@ -6,6 +6,8 @@ import { handleSubscriptions } from './routes/subscriptions.ts';
 import { handleSongs } from './routes/songs.ts';
 import { handleLibrary } from './routes/library.ts';
 import { handleQuota } from './routes/quota.ts';
+import { handleVerify } from './routes/verify.ts';
+import { handleComplete } from './routes/complete.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
@@ -32,6 +34,12 @@ serve(async (req) => {
     if (response) return response;
 
     response = await handleQuota(req, supabase, path);
+    if (response) return response;
+
+    response = await handleVerify(req, supabase, path);
+    if (response) return response;
+
+    response = await handleComplete(req, supabase, path);
     if (response) return response;
 
     return new Response(

--- a/supabase/functions/med-mng-api/routes/complete.ts
+++ b/supabase/functions/med-mng-api/routes/complete.ts
@@ -1,0 +1,132 @@
+import { corsHeaders } from '../types.ts';
+import { verifyItem } from './verify.ts';
+
+export async function handleComplete(req: Request, supabase: any, path: string) {
+  if (path.startsWith('/complete-item/') && req.method === 'POST') {
+    const itemId = path.split('/')[2];
+    const report = await completeItem(supabase, itemId);
+    return new Response(
+      JSON.stringify(report),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  if (path === '/complete-all' && req.method === 'POST') {
+    const { data: items, error } = await supabase
+      .from('med_mng_items')
+      .select('id');
+    if (error) throw error;
+
+    const results = [] as any[];
+    for (const item of items) {
+      results.push(await completeItem(supabase, item.id));
+    }
+
+    return new Response(
+      JSON.stringify(results),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  return null;
+}
+
+async function completeItem(supabase: any, itemId: string) {
+  const initialReport = await verifyItem(supabase, itemId);
+  const generated: string[] = [];
+
+  if (!initialReport.checks.roman) {
+    await generateRoman(supabase, itemId);
+    generated.push('roman');
+  }
+  if (!initialReport.checks.comic_panels) {
+    await generateComic(supabase, itemId);
+    generated.push('comic');
+  }
+  if (!initialReport.checks.music) {
+    await generateMusic(supabase, itemId);
+    generated.push('music');
+  }
+  if (!initialReport.checks.quiz) {
+    await generateQuiz(supabase, itemId);
+    generated.push('quiz');
+  }
+
+  const finalReport = await verifyItem(supabase, itemId);
+  return { item_id: itemId, generated, report: finalReport };
+}
+
+async function generateRoman(supabase: any, itemId: string) {
+  const { data: item } = await supabase
+    .from('med_mng_items')
+    .select('item_number, title')
+    .eq('id', itemId)
+    .single();
+  if (!item) return;
+  const prompt = `Rédige un roman pédagogique complet pour l\'item ${item.item_number} : ${item.title}`;
+  await callFunction('generate-content', {
+    prompt,
+    format: 'novel',
+    item_code: item.item_number,
+    content_type: 'novel'
+  });
+}
+
+async function generateComic(supabase: any, itemId: string) {
+  const { data: item } = await supabase
+    .from('med_mng_items')
+    .select('item_number, title')
+    .eq('id', itemId)
+    .single();
+  if (!item) return;
+  const prompt = `Bande dessinee medicale pour l\'item ${item.item_number} - ${item.title}`;
+  await callFunction('generate-comic-images', {
+    scene_description: prompt,
+    item_code: `IC-${item.item_number}`
+  });
+}
+
+async function generateMusic(supabase: any, itemId: string) {
+  const { data: item } = await supabase
+    .from('med_mng_items')
+    .select('item_number')
+    .eq('id', itemId)
+    .single();
+  if (!item) return;
+  await callFunction('generate-music', {
+    lyrics: `Item ${item.item_number}`,
+    style: 'pop',
+    rang: 'A',
+    itemCode: `IC-${item.item_number}`
+  });
+}
+
+async function generateQuiz(supabase: any, itemId: string) {
+  const { data: item } = await supabase
+    .from('med_mng_items')
+    .select('item_number, title')
+    .eq('id', itemId)
+    .single();
+  if (!item) return;
+  const prompt = `Crée un quiz médical corrigé pour l\'item ${item.item_number} - ${item.title}`;
+  await callFunction('generate-content', {
+    prompt,
+    format: 'quiz',
+    item_code: item.item_number,
+    content_type: 'quiz'
+  });
+}
+
+async function callFunction(name: string, body: Record<string, unknown>) {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRole = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !serviceRole) return;
+  await fetch(`${supabaseUrl}/functions/v1/${name}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${serviceRole}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+}

--- a/supabase/functions/med-mng-api/routes/verify.ts
+++ b/supabase/functions/med-mng-api/routes/verify.ts
@@ -1,0 +1,74 @@
+import { corsHeaders } from '../types.ts';
+
+export async function handleVerify(req: Request, supabase: any, path: string) {
+  // GET /verify-item/:id
+  if (path.startsWith('/verify-item/') && req.method === 'GET') {
+    const itemId = path.split('/')[2];
+    const report = await verifyItem(supabase, itemId);
+    return new Response(
+      JSON.stringify(report),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // GET /verify-all
+  if (path === '/verify-all' && req.method === 'GET') {
+    const { data: items, error } = await supabase
+      .from('med_mng_items')
+      .select('id');
+    if (error) throw error;
+
+    const results = [] as any[];
+    for (const item of items) {
+      results.push(await verifyItem(supabase, item.id));
+    }
+
+    return new Response(
+      JSON.stringify(results),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  return null;
+}
+
+export async function verifyItem(supabase: any, itemId: string) {
+  const checks: Record<string, boolean> = {};
+
+  const { count: comicCount } = await supabase
+    .from('comic_panels')
+    .select('id', { count: 'exact', head: true })
+    .eq('item_id', itemId);
+  checks.comic_panels = (comicCount || 0) > 0;
+
+  const { count: novelCount } = await supabase
+    .from('roman_versions')
+    .select('id', { count: 'exact', head: true })
+    .eq('item_id', itemId);
+  checks.roman = (novelCount || 0) > 0;
+
+  const { count: musicCount } = await supabase
+    .from('music_tracks')
+    .select('id', { count: 'exact', head: true })
+    .eq('item_id', itemId);
+  checks.music = (musicCount || 0) > 0;
+
+  const { count: quizCount } = await supabase
+    .from('quiz_questions')
+    .select('id', { count: 'exact', head: true })
+    .eq('item_id', itemId);
+  checks.quiz = (quizCount || 0) > 0;
+
+  const isValid = Object.values(checks).every(Boolean);
+
+  await supabase
+    .from('med_mng_items')
+    .update({ is_validated: isValid, last_checked_at: new Date().toISOString() })
+    .eq('id', itemId);
+
+  await supabase
+    .from('audit_logs')
+    .insert({ item_id: itemId, success: isValid, report: checks });
+
+  return { item_id: itemId, is_validated: isValid, checks };
+}

--- a/supabase/migrations/20250712120000-bfc4e2f5-c2ab-4f8e-b62a-6cfe6b0b1234.sql
+++ b/supabase/migrations/20250712120000-bfc4e2f5-c2ab-4f8e-b62a-6cfe6b0b1234.sql
@@ -1,0 +1,71 @@
+-- Création des tables de contenus pédagogiques complémentaires
+
+-- Table principale des items (meta)
+CREATE TABLE IF NOT EXISTS public.med_mng_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_number INTEGER NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  item_type TEXT,
+  is_validated BOOLEAN DEFAULT FALSE,
+  is_static BOOLEAN DEFAULT FALSE,
+  last_checked_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Table des vignettes de bande dessinée générées
+CREATE TABLE IF NOT EXISTS public.comic_panels (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID REFERENCES public.med_mng_items(id) ON DELETE CASCADE,
+  panel_number INTEGER NOT NULL,
+  image_url TEXT NOT NULL,
+  prompt TEXT,
+  is_static BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Table des versions de romans pédagogiques
+CREATE TABLE IF NOT EXISTS public.roman_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID REFERENCES public.med_mng_items(id) ON DELETE CASCADE,
+  text TEXT NOT NULL,
+  source_prompt TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Table des pistes musicales liées aux items
+CREATE TABLE IF NOT EXISTS public.music_tracks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID REFERENCES public.med_mng_items(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  track_url TEXT NOT NULL,
+  is_static BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Table des questions de quiz interactif
+CREATE TABLE IF NOT EXISTS public.quiz_questions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID REFERENCES public.med_mng_items(id) ON DELETE CASCADE,
+  question TEXT NOT NULL,
+  answer TEXT NOT NULL,
+  feedback TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Table des journaux d'audit de vérification
+CREATE TABLE IF NOT EXISTS public.audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID REFERENCES public.med_mng_items(id) ON DELETE CASCADE,
+  success BOOLEAN,
+  report JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Activer la sécurité au niveau des lignes
+ALTER TABLE public.med_mng_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.comic_panels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.roman_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.music_tracks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.quiz_questions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_logs ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- expose new POST endpoints to generate missing content
- add route handler calling other functions to fill novels, comics, music and quizzes
- export `verifyItem` helper
- document new API endpoints

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870c9d341d4832d884f0f3cdb158db9