### PR TITLE
Add UNES scraping helper scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-key
 
 # Auth credentials for CAS or other systems
+# UNES credentials for scraping
+UNES_EMAIL=
+UNES_PASSWORD=
 CAS_USER=
 CAS_PASS=
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 coverage
+__pycache__/

--- a/unes_tools/README.md
+++ b/unes_tools/README.md
@@ -1,0 +1,32 @@
+# UNES Scraper
+
+This folder contains helper scripts to extract items from the UNES LiSA 2025 platform and store them in Supabase.
+
+## Files
+
+- `unes_scraper.py` – main scraper that authenticates to UNES, retrieves each item and its printable version, then saves the data in Supabase.
+- `upload_to_supabase.py` – small helper exposing functions to upsert items and competences using the Supabase API.
+- `audit_items.py` – verifies that all items are stored and that each has at least one competence of rank A. Outputs an `incomplets.json` report.
+
+## Usage
+
+1. Install Python dependencies:
+   ```bash
+   pip install requests beautifulsoup4 supabase
+   ```
+2. Copy `.env.example` to `.env` and fill in your Supabase and UNES credentials.
+3. Run the scraper:
+   ```bash
+   python unes_scraper.py
+   ```
+4. To verify the database content:
+   ```bash
+   python audit_items.py
+   ```
+
+All scripts rely on the following environment variables:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `UNES_EMAIL`
+- `UNES_PASSWORD`
+

--- a/unes_tools/audit_items.py
+++ b/unes_tools/audit_items.py
@@ -1,0 +1,32 @@
+import json
+import os
+from supabase import create_client
+
+SUPABASE_URL = os.getenv('SUPABASE_URL')
+SUPABASE_KEY = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    raise RuntimeError('Supabase credentials missing')
+
+supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def audit_items(start=1, end=367, output_file='incomplets.json'):
+    incomplets = []
+    for num in range(start, end + 1):
+        item_resp = supabase.table('items_edn').select('id').eq('numero_item', num).execute()
+        if not item_resp.data:
+            incomplets.append({'numero_item': num, 'reason': 'missing'})
+            continue
+        item_id = item_resp.data[0]['id']
+        comp_resp = supabase.table('competences').select('id').eq('item_id', item_id).eq('rang', 'A').execute()
+        if not comp_resp.data:
+            incomplets.append({'numero_item': num, 'reason': 'no_rang_a'})
+    with open(output_file, 'w') as f:
+        json.dump(incomplets, f, indent=2)
+    return incomplets
+
+
+if __name__ == '__main__':
+    audit_items()
+

--- a/unes_tools/unes_scraper.py
+++ b/unes_tools/unes_scraper.py
@@ -1,0 +1,105 @@
+import os
+import re
+import time
+import sys
+from pathlib import Path
+import requests
+from bs4 import BeautifulSoup
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from upload_to_supabase import upsert_item, upsert_competence
+
+UNES_EMAIL = os.getenv('UNES_EMAIL')
+UNES_PASSWORD = os.getenv('UNES_PASSWORD')
+
+BASE_URL = 'https://livret.uness.fr'
+LIST_URL = f'{BASE_URL}/lisa/2025/Catégorie:Objectif_de_connaissance'
+ITEM_URL_TEMPLATE = f'{BASE_URL}/lisa/2025/Item_de_connaissance_%d'
+
+
+class UNESScraper:
+    def __init__(self):
+        if not UNES_EMAIL or not UNES_PASSWORD:
+            raise RuntimeError('UNES credentials missing')
+        self.session = requests.Session()
+
+    def authenticate(self):
+        # step 1: email
+        self.session.post(
+            'https://cockpit.uness.fr/api/auth/email',
+            json={'email': UNES_EMAIL},
+            headers={'Accept': 'application/json'}
+        )
+        # step 2: password
+        self.session.post(
+            'https://cockpit.uness.fr/login',
+            data={'email': UNES_EMAIL, 'password': UNES_PASSWORD},
+            headers={'Content-Type': 'application/x-www-form-urlencoded'}
+        )
+
+    def fetch_printable(self, url: str) -> str:
+        r = self.session.get(url)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, 'html.parser')
+        link = soup.find('a', string=re.compile('version imprimable', re.I))
+        if link and link.get('href'):
+            printable_url = link['href']
+            if not printable_url.startswith('http'):
+                printable_url = BASE_URL + printable_url
+            r = self.session.get(printable_url)
+            r.raise_for_status()
+            return r.text
+        return r.text
+
+    def parse_competences(self, html: str):
+        soup = BeautifulSoup(html, 'html.parser')
+        rang_a, rang_b = [], []
+        headings = soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5'])
+        for h in headings:
+            text = h.get_text().lower()
+            if 'rang a' in text:
+                rang_a += self._extract_section_text(h)
+            if 'rang b' in text:
+                rang_b += self._extract_section_text(h)
+        return rang_a, rang_b
+
+    def _extract_section_text(self, heading):
+        content = []
+        for sib in heading.find_next_siblings():
+            if sib.name in ['h1', 'h2', 'h3', 'h4', 'h5']:
+                break
+            if sib.name in ['p', 'li']:
+                text = sib.get_text(strip=True)
+                if text:
+                    content.append(text)
+        return content
+
+    def run(self, start=1, end=367):
+        self.authenticate()
+        for i in range(start, end + 1):
+            url = ITEM_URL_TEMPLATE % i
+            try:
+                html = self.fetch_printable(url)
+            except requests.HTTPError:
+                continue
+            soup = BeautifulSoup(html, 'html.parser')
+            title_tag = soup.find('h1') or soup.find('title')
+            titre = title_tag.get_text(strip=True) if title_tag else f'Item {i}'
+            item_id = upsert_item(i, titre, html)
+            rang_a, rang_b = self.parse_competences(html)
+            for text in rang_a:
+                upsert_competence(item_id, 'A', text)
+            for text in rang_b:
+                upsert_competence(item_id, 'B', text)
+            time.sleep(1)
+
+
+def main():
+    scraper = UNESScraper()
+    scraper.run()
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/unes_tools/upload_to_supabase.py
+++ b/unes_tools/upload_to_supabase.py
@@ -1,0 +1,38 @@
+import os
+from supabase import create_client, Client
+
+SUPABASE_URL = os.getenv('SUPABASE_URL')
+SUPABASE_KEY = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    raise RuntimeError('Supabase credentials are missing')
+
+supabase: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def upsert_item(numero_item: int, titre: str, contenu_html: str) -> int:
+    """Insert or update an item. Returns the item id."""
+    result = supabase.table('items_edn').upsert(
+        {
+            'numero_item': numero_item,
+            'titre': titre,
+            'contenu_html': contenu_html,
+        },
+        on_conflict='numero_item',
+        returning='representation'
+    ).execute()
+    if result.data:
+        return result.data[0]['id']
+    raise RuntimeError(f'Item insertion failed: {result}')
+
+
+def upsert_competence(item_id: int, rang: str, texte: str) -> None:
+    supabase.table('competences').upsert(
+        {
+            'item_id': item_id,
+            'rang': rang,
+            'texte': texte,
+        },
+        on_conflict='item_id, rang, texte'
+    ).execute()
+


### PR DESCRIPTION
## Summary
- add Python utilities for scraping UNES items and uploading to Supabase
- document usage in `unes_tools/README.md`
- extend `.env.example` with UNES credentials
- ignore Python `__pycache__`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a4c02260832d89e0e1ae05f5389f