### PR TITLE
Add package manifests for backend services

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@med-mng/api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "supabase functions serve --env-file ../../.env",
+    "build": "tsc --noEmit",
+    "deploy": "supabase functions deploy",
+    "test": "deno test --allow-all",
+    "test:e2e": "deno test --allow-all test/e2e",
+    "typecheck": "tsc --noEmit",
+    "lint": "deno lint",
+    "format": "deno fmt"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0",
+    "stripe": "^14.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.2"
+  }
+}

--- a/apps/cron/package.json
+++ b/apps/cron/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@med-mng/cron",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0",
+    "bullmq": "^5.0.0",
+    "cron": "^3.1.6",
+    "ioredis": "^5.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsx": "^4.6.2",
+    "typescript": "^5.3.2"
+  }
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@med-mng/worker",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0",
+    "axios": "^1.6.2",
+    "bullmq": "^5.0.0",
+    "ioredis": "^5.3.2",
+    "nodemailer": "^6.9.7",
+    "openai": "^4.20.1",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "@types/nodemailer": "^6.4.14",
+    "tsx": "^4.6.2",
+    "typescript": "^5.3.2",
+    "vitest": "^1.0.4"
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@med-mng/shared",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "seed": "tsx src/seed.ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsx": "^4.6.2",
+    "typescript": "^5.3.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json for API supabase functions
- add worker package.json with dev/test scripts
- add cron job package.json
- add shared package manifest

## Testing
- `apt-get update`
- `apt-get install -y nodejs npm` *(failed: node not installed)*
- `node --version` *(failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878e5f92098832d882a93baee818e04