### PR TITLE
Add shared schemas and utilities

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,0 +1,55 @@
+export const QUOTAS = {
+  FREE: {
+    DAILY_SONGS: 5,
+    MONTHLY_SONGS: 50,
+    MAX_PLAYLIST_COUNT: 3,
+    MAX_PLAYLIST_SONGS: 20,
+  },
+  PRO: {
+    DAILY_SONGS: 20,
+    MONTHLY_SONGS: 500,
+    MAX_PLAYLIST_COUNT: -1, // unlimited
+    MAX_PLAYLIST_SONGS: -1,
+  },
+} as const;
+
+export const POINTS = {
+  COMPLETE_SESSION: 10,
+  PERFECT_QUIZ: 50,
+  DAILY_STREAK: 5,
+  WEEKLY_STREAK_BONUS: 50,
+  MONTHLY_STREAK_BONUS: 200,
+  FIRST_SONG: 20,
+  SHARE_PLAYLIST: 15,
+} as const;
+
+export const ACHIEVEMENTS = {
+  FIRST_STEPS: {
+    id: 'first_steps',
+    name: 'First Steps',
+    description: 'Complete your first learning session',
+    points: 50,
+    criteria: { sessions_completed: 1 },
+  },
+  STREAK_WEEK: {
+    id: 'streak_week',
+    name: 'Week Warrior',
+    description: 'Maintain a 7-day learning streak',
+    points: 100,
+    criteria: { streak_days: 7 },
+  },
+  QUIZ_MASTER: {
+    id: 'quiz_master',
+    name: 'Quiz Master',
+    description: 'Get 10 perfect quiz scores',
+    points: 200,
+    criteria: { perfect_quizzes: 10 },
+  },
+  SONG_CREATOR: {
+    id: 'song_creator',
+    name: 'Song Creator',
+    description: 'Generate 25 medical songs',
+    points: 150,
+    criteria: { songs_created: 25 },
+  },
+} as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './constants';
+export * from './utils';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+
+// Enums
+export const SubscriptionStatus = z.enum([
+  'active',
+  'cancelled',
+  'past_due',
+  'trialing',
+]);
+export const DifficultyLevel = z.enum([
+  'beginner',
+  'intermediate',
+  'advanced',
+  'expert',
+]);
+export const ContentType = z.enum(['song', 'quiz', 'flashcard', 'article']);
+
+// User schemas
+export const UserProfileSchema = z.object({
+  id: z.string().uuid(),
+  display_name: z.string().nullable(),
+  avatar_url: z.string().url().nullable(),
+  specialization: z.string().nullable(),
+  study_level: DifficultyLevel,
+  daily_goal: z.number().int().positive(),
+  streak_days: z.number().int().min(0),
+  total_study_time: z.number().int().min(0),
+  points: z.number().int().min(0),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+// Medical content schemas
+export const MedicalTopicSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  category: z.string(),
+  parent_id: z.string().uuid().nullable(),
+  difficulty_level: DifficultyLevel,
+  description: z.string().nullable(),
+  icon_url: z.string().url().nullable(),
+  order_index: z.number().int(),
+});
+
+export const SongSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  topic_id: z.string().uuid().nullable(),
+  title: z.string(),
+  artist: z.string().nullable(),
+  suno_id: z.string().nullable(),
+  audio_url: z.string().url().nullable(),
+  image_url: z.string().url().nullable(),
+  lyrics: z.string().nullable(),
+  medical_content: z.record(z.any()).nullable(),
+  duration: z.number().int().nullable(),
+  play_count: z.number().int().default(0),
+  is_public: z.boolean().default(false),
+  status: z.enum(['pending', 'generating', 'completed', 'failed']).optional(),
+  created_at: z.string().datetime(),
+});
+
+// Learning schemas
+export const LearningSessionSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  content_id: z.string().uuid(),
+  content_type: ContentType,
+  topic_id: z.string().uuid().nullable(),
+  started_at: z.string().datetime(),
+  completed_at: z.string().datetime().nullable(),
+  duration_seconds: z.number().int().nullable(),
+  score: z.number().min(0).max(100).nullable(),
+  notes: z.string().nullable(),
+  feedback: z.record(z.any()).nullable(),
+});
+
+export const QuizQuestionSchema = z.object({
+  id: z.string().uuid(),
+  topic_id: z.string().uuid(),
+  question: z.string(),
+  options: z.array(
+    z.object({
+      text: z.string(),
+      is_correct: z.boolean(),
+      explanation: z.string().optional(),
+    })
+  ),
+  difficulty_level: DifficultyLevel,
+  explanation: z.string().nullable(),
+  references: z.array(z.string()),
+});
+
+// API Request/Response schemas
+export const CreateSongRequestSchema = z.object({
+  topic_id: z.string().uuid(),
+  prompt: z.string().min(10).max(500),
+  medical_content: z
+    .object({
+      terms: z.array(z.string()).optional(),
+      concepts: z.array(z.string()).optional(),
+      mnemonics: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const CompleteSessionRequestSchema = z.object({
+  score: z.number().min(0).max(100).optional(),
+  notes: z.string().optional(),
+  feedback: z
+    .object({
+      difficulty: z.enum(['too_easy', 'just_right', 'too_hard']).optional(),
+      helpful: z.boolean().optional(),
+      comments: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const QuizAnswerRequestSchema = z.object({
+  question_id: z.string().uuid(),
+  topic_id: z.string().uuid(),
+  selected_option: z.number().int().min(0),
+  is_correct: z.boolean(),
+});
+
+// Type exports
+export type UserProfile = z.infer<typeof UserProfileSchema>;
+export type MedicalTopic = z.infer<typeof MedicalTopicSchema>;
+export type Song = z.infer<typeof SongSchema>;
+export type LearningSession = z.infer<typeof LearningSessionSchema>;
+export type QuizQuestion = z.infer<typeof QuizQuestionSchema>;
+export type CreateSongRequest = z.infer<typeof CreateSongRequestSchema>;
+export type CompleteSessionRequest = z.infer<
+  typeof CompleteSessionRequestSchema
+>;
+export type QuizAnswerRequest = z.infer<typeof QuizAnswerRequestSchema>;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,0 +1,48 @@
+export function calculateMasteryLevel(
+  correctAnswers: number,
+  totalQuestions: number,
+  reviewCount: number
+): number {
+  if (totalQuestions === 0) return 0;
+
+  const accuracy = correctAnswers / totalQuestions;
+  const practiceBonus = Math.min(reviewCount * 0.05, 0.2); // Max 20% bonus
+
+  return Math.min(accuracy + practiceBonus, 1);
+}
+
+export function getNextReviewDate(
+  masteryLevel: number,
+  lastReviewed: Date
+): Date {
+  // Spaced repetition intervals based on mastery
+  const daysUntilReview = Math.floor(
+    masteryLevel < 0.3
+      ? 1
+      : masteryLevel < 0.5
+        ? 3
+        : masteryLevel < 0.7
+          ? 7
+          : masteryLevel < 0.9
+            ? 14
+            : 30
+  );
+
+  const nextDate = new Date(lastReviewed);
+  nextDate.setDate(nextDate.getDate() + daysUntilReview);
+  return nextDate;
+}
+
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else if (minutes > 0) {
+    return `${minutes}m ${secs}s`;
+  } else {
+    return `${secs}s`;
+  }
+}


### PR DESCRIPTION
## Summary
- define zod schemas and types for user profiles, songs, topics, and learning sessions
- add shared constants for quotas, points and achievements
- implement mastery helpers in a utils module
- expose the new modules from `packages/shared`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e60f969c832d82c95946162a2476