### PR TITLE
Add Suno music generation support

### DIFF
--- a/supabase/functions/check-pending-songs/index.ts
+++ b/supabase/functions/check-pending-songs/index.ts
@@ -1,0 +1,77 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+serve(async (req) => {
+  try {
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    // Récupérer chansons en attente depuis plus de 5 minutes
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    
+    const { data: pendingSongs, error } = await supabaseClient
+      .from('songs')
+      .select('*')
+      .eq('status', 'generating')
+      .lt('created_at', fiveMinutesAgo);
+
+    if (error) throw error;
+
+    console.log(`🔍 ${pendingSongs?.length || 0} chansons en attente trouvées`);
+
+    let updatedCount = 0;
+
+    // Vérifier chaque chanson via l'API Suno
+    for (const song of pendingSongs || []) {
+      try {
+        console.log(`🔍 Vérification chanson: ${song.suno_id}`);
+        
+        const response = await fetch(`https://api.suno.ai/v1/songs/${song.suno_id}`, {
+          headers: {
+            'Authorization': `Bearer ${Deno.env.get('SUNO_API_KEY')}`,
+            'Content-Type': 'application/json'
+          },
+        });
+
+        if (!response.ok) {
+          console.error(`❌ Erreur API Suno pour ${song.suno_id}:`, response.status);
+          continue;
+        }
+
+        const sunoData = await response.json();
+        console.log(`📊 Status Suno pour ${song.suno_id}:`, sunoData.status);
+        
+        // Mettre à jour si le statut a changé
+        if (sunoData.status !== song.status) {
+          await supabaseClient
+            .from('songs')
+            .update({
+              status: sunoData.status,
+              audio_url: sunoData.audio_url || song.audio_url,
+              video_url: sunoData.video_url || song.video_url,
+              updated_at: new Date().toISOString(),
+              manual_check_at: new Date().toISOString()
+            })
+            .eq('id', song.id);
+          
+          updatedCount++;
+          console.log(`✅ Chanson ${song.id} mise à jour: ${sunoData.status}`);
+        }
+      } catch (err) {
+        console.error(`💥 Erreur vérification ${song.id}:`, err);
+      }
+    }
+
+    return new Response(JSON.stringify({
+      success: true,
+      checked: pendingSongs?.length || 0,
+      updated: updatedCount
+    }));
+
+  } catch (error) {
+    console.error('💥 Erreur check pending:', error);
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+  }
+});

--- a/supabase/functions/cron-check-songs/index.ts
+++ b/supabase/functions/cron-check-songs/index.ts
@@ -1,0 +1,17 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+// À exécuter toutes les 5 minutes
+serve(async (req) => {
+  // Appeler la fonction de vérification
+  const response = await fetch(`${Deno.env.get('SUPABASE_URL')}/functions/v1/check-pending-songs`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`
+    }
+  });
+
+  const result = await response.json();
+  console.log('🔄 CRON check résultat:', result);
+
+  return new Response(JSON.stringify(result));
+});

--- a/supabase/functions/generate-music-callback/index.ts
+++ b/supabase/functions/generate-music-callback/index.ts
@@ -1,0 +1,104 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    console.log('🎵 Callback reçu de Suno API');
+    
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    // Parse callback data
+    const body = await req.json();
+    console.log('📊 Données callback:', JSON.stringify(body, null, 2));
+
+    const { id: sunoId, status, audio_url, video_url, title, tags, model_name } = body;
+
+    if (!sunoId) {
+      throw new Error('❌ ID Suno manquant dans le callback');
+    }
+
+    // Update song in database
+    const { data: songData, error: updateError } = await supabaseClient
+      .from('songs')
+      .update({
+        status: status,
+        audio_url: audio_url || null,
+        video_url: video_url || null,
+        suno_title: title || null,
+        suno_tags: tags || null,
+        model_name: model_name || null,
+        updated_at: new Date().toISOString(),
+        callback_received_at: new Date().toISOString()
+      })
+      .eq('suno_id', sunoId)
+      .select();
+
+    if (updateError) {
+      console.error('❌ Erreur mise à jour:', updateError);
+      throw updateError;
+    }
+
+    if (!songData || songData.length === 0) {
+      console.error('❌ Aucune chanson trouvée avec suno_id:', sunoId);
+      throw new Error(`Chanson non trouvée: ${sunoId}`);
+    }
+
+    const song = songData[0];
+    console.log('✅ Chanson mise à jour:', song.title, '- Status:', status);
+
+    // If complete, send notification
+    if (status === 'complete' && audio_url) {
+      console.log('🎉 Génération terminée pour:', song.title);
+      
+      // Trigger real-time update
+      await supabaseClient
+        .from('songs')
+        .update({ 
+          last_notification_sent: new Date().toISOString() 
+        })
+        .eq('id', song.id);
+    }
+
+    return new Response(
+      JSON.stringify({ 
+        success: true, 
+        message: 'Callback traité avec succès',
+        songId: song.id,
+        status: status
+      }),
+      { 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200 
+      }
+    );
+
+  } catch (error) {
+    console.error('💥 Erreur callback:', error);
+    
+    return new Response(
+      JSON.stringify({ 
+        success: false, 
+        error: error.message,
+        timestamp: new Date().toISOString()
+      }),
+      { 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 500 
+      }
+    );
+  }
+});
+

--- a/supabase/functions/generate-song/index.ts
+++ b/supabase/functions/generate-song/index.ts
@@ -1,0 +1,85 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseClient = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  // Ajouter plus de logs et validation
+  try {
+    const { prompt, style, duration, title } = await req.json();
+    
+    // Validation
+    if (!prompt || prompt.length < 10) {
+      throw new Error('Prompt trop court (minimum 10 caractères)');
+    }
+    
+    console.log('🎵 Démarrage génération:', { prompt, style, duration });
+    
+    // Appel Suno avec gestion d'erreur
+    const sunoResponse = await fetch('https://api.suno.ai/v1/songs', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${Deno.env.get('SUNO_API_KEY')}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        prompt,
+        style,
+        duration,
+        title,
+        tags: `medical,learning,${style}`,
+        callback_url: `${Deno.env.get('SUPABASE_URL')}/functions/v1/generate-music-callback`,
+        wait_audio: false // Important: ne pas attendre
+      })
+    });
+
+    if (!sunoResponse.ok) {
+      const errorText = await sunoResponse.text();
+      console.error('❌ Erreur Suno API:', sunoResponse.status, errorText);
+      throw new Error(`Erreur Suno: ${sunoResponse.status}`);
+    }
+
+    const sunoData = await sunoResponse.json();
+    console.log('✅ Réponse Suno:', sunoData);
+
+    // Sauvegarder en BDD
+    const { data: song, error } = await supabaseClient
+      .from('songs')
+      .insert({
+        suno_id: sunoData.id,
+        title: title,
+        prompt: prompt,
+        style: style,
+        duration: duration,
+        status: sunoData.status || 'generating',
+        created_at: new Date().toISOString()
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return new Response(JSON.stringify({
+      success: true,
+      songId: song.id,
+      sunoId: sunoData.id,
+      status: sunoData.status
+    }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+
+  } catch (error) {
+    console.error('💥 Erreur génération:', error);
+    return new Response(JSON.stringify({ error: error.message }), { status: 500, headers: corsHeaders });
+  }
+});


### PR DESCRIPTION
## Summary
- implement `generate-music-callback` Supabase function to handle Suno callbacks
- add `check-pending-songs` and a cron wrapper for periodic checks
- create `generate-song` function using Suno API with validation

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a15fea7fc832d95293ebba07ca251