### PR TITLE
Add responsive navigation layout

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import { MainNavigation } from '../Navigation/MainNavigation'
+import { Breadcrumb } from '../Navigation/Breadcrumb'
+import { Menu, X } from 'lucide-react'
+
+interface AppLayoutProps {
+  children: React.ReactNode
+}
+
+export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+
+  return (
+    <div className="app-layout">
+      {/* Navigation mobile */}
+      <div className="mobile-header">
+        <div className="mobile-header-content">
+          <span className="mobile-logo">MED-MNG</span>
+          <button
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            className="mobile-menu-toggle"
+          >
+            {isMobileMenuOpen ? <X /> : <Menu />}
+          </button>
+        </div>
+      </div>
+
+      {/* Overlay mobile */}
+      {isMobileMenuOpen && (
+        <div className="mobile-overlay" onClick={() => setIsMobileMenuOpen(false)} />
+      )}
+
+      {/* Sidebar navigation */}
+      <aside className={`sidebar ${isMobileMenuOpen ? 'mobile-open' : ''}`}>
+        <MainNavigation />
+      </aside>
+
+      {/* Contenu principal */}
+      <main className="main-content">
+        <div className="content-header">
+          <Breadcrumb />
+        </div>
+
+        <div className="content-body">{children}</div>
+      </main>
+    </div>
+  )
+}

--- a/src/components/Navigation/Breadcrumb.tsx
+++ b/src/components/Navigation/Breadcrumb.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { useLocation, Link } from 'react-router-dom'
+import { ChevronRight, Home } from 'lucide-react'
+
+interface BreadcrumbItem {
+  label: string
+  path: string
+  isActive?: boolean
+}
+
+export const Breadcrumb: React.FC = () => {
+  const location = useLocation()
+
+  const generateBreadcrumbs = (): BreadcrumbItem[] => {
+    const pathSegments = location.pathname.split('/').filter(Boolean)
+    const breadcrumbs: BreadcrumbItem[] = [
+      { label: 'Accueil', path: '/' }
+    ]
+
+    let currentPath = ''
+    pathSegments.forEach((segment, index) => {
+      currentPath += `/${segment}`
+
+      const labelMap: Record<string, string> = {
+        'rang-a': 'Rang A',
+        'rang-b': 'Rang B',
+        'musique': 'Musique',
+        'scene': 'Scène',
+        'quiz': 'Quiz',
+        'bd': 'Bande Dessinée',
+        'roman': 'Roman',
+        'edn-complete': 'EDN Complet'
+      }
+
+      breadcrumbs.push({
+        label: labelMap[segment] || segment.charAt(0).toUpperCase() + segment.slice(1),
+        path: currentPath,
+        isActive: index === pathSegments.length - 1
+      })
+    })
+
+    return breadcrumbs
+  }
+
+  const breadcrumbs = generateBreadcrumbs()
+
+  return (
+    <nav className="breadcrumb" aria-label="Breadcrumb">
+      <ol className="breadcrumb-list">
+        {breadcrumbs.map((item, index) => (
+          <li key={item.path} className="breadcrumb-item">
+            {index === 0 && <Home className="w-4 h-4" />}
+
+            {item.isActive ? (
+              <span className="breadcrumb-current" aria-current="page">
+                {item.label}
+              </span>
+            ) : (
+              <Link to={item.path} className="breadcrumb-link">
+                {item.label}
+              </Link>
+            )}
+
+            {index < breadcrumbs.length - 1 && (
+              <ChevronRight className="breadcrumb-separator w-4 h-4" />
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}

--- a/src/components/Navigation/MainNavigation.tsx
+++ b/src/components/Navigation/MainNavigation.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  Music,
+  BookOpen,
+  Users,
+  HelpCircle,
+  Book,
+  FileText,
+  Star
+} from 'lucide-react'
+
+interface NavItem {
+  id: string
+  label: string
+  path: string
+  icon: React.ReactNode
+  description: string
+  badge?: string
+}
+
+const navItems: NavItem[] = [
+  {
+    id: 'rang-a',
+    label: 'Rang A',
+    path: '/rang-a',
+    icon: <Star className="w-5 h-5" />,
+    description: 'Items de connaissance Rang A',
+    badge: 'Avancé'
+  },
+  {
+    id: 'rang-b',
+    label: 'Rang B',
+    path: '/rang-b',
+    icon: <BookOpen className="w-5 h-5" />,
+    description: 'Items de connaissance Rang B'
+  },
+  {
+    id: 'musique',
+    label: 'Musique',
+    path: '/musique',
+    icon: <Music className="w-5 h-5" />,
+    description: 'Génération musicale avec IA'
+  },
+  {
+    id: 'scene',
+    label: 'Scène',
+    path: '/scene',
+    icon: <Users className="w-5 h-5" />,
+    description: 'Scénarios cliniques interactifs'
+  },
+  {
+    id: 'quiz',
+    label: 'Quiz',
+    path: '/quiz',
+    icon: <HelpCircle className="w-5 h-5" />,
+    description: 'Évaluations et tests'
+  },
+  {
+    id: 'bd',
+    label: 'BD',
+    path: '/bd',
+    icon: <Book className="w-5 h-5" />,
+    description: 'Bandes dessinées éducatives'
+  },
+  {
+    id: 'roman',
+    label: 'Roman',
+    path: '/roman',
+    icon: <FileText className="w-5 h-5" />,
+    description: 'Romans médicaux'
+  }
+]
+
+export const MainNavigation: React.FC = () => {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const isActive = (path: string) => {
+    return location.pathname === path || location.pathname.startsWith(path + '/')
+  }
+
+  return (
+    <nav className="main-navigation">
+      <div className="nav-container">
+        {/* Logo et titre */}
+        <div className="nav-header">
+          <div className="logo">
+            <span className="logo-text">MED-MNG</span>
+            <span className="logo-subtitle">par EmotionsCare</span>
+          </div>
+        </div>
+
+        {/* Navigation principale */}
+        <div className="nav-items">
+          {navItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => navigate(item.path)}
+              className={`nav-item ${isActive(item.path) ? 'active' : ''}`}
+              title={item.description}
+            >
+              <div className="nav-item-icon">{item.icon}</div>
+              <div className="nav-item-content">
+                <span className="nav-item-label">{item.label}</span>
+                <span className="nav-item-description">{item.description}</span>
+              </div>
+              {item.badge && <span className="nav-item-badge">{item.badge}</span>}
+            </button>
+          ))}
+        </div>
+
+        {/* Indicateur de progression */}
+        <div className="nav-progress">
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: '60%' }} />
+          </div>
+          <span className="progress-text">Progression: 6/10 modules</span>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/UI/FeedbackStates.tsx
+++ b/src/components/UI/FeedbackStates.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { CheckCircle, XCircle, AlertCircle, Info, Loader } from 'lucide-react'
+
+type FeedbackType = 'success' | 'error' | 'warning' | 'info' | 'loading'
+
+interface FeedbackMessageProps {
+  type: FeedbackType
+  title?: string
+  message: string
+  actions?: React.ReactNode
+  onDismiss?: () => void
+  autoHide?: boolean
+  duration?: number
+}
+
+const iconMap = {
+  success: CheckCircle,
+  error: XCircle,
+  warning: AlertCircle,
+  info: Info,
+  loading: Loader
+}
+
+const colorMap = {
+  success: 'text-green-600 bg-green-50 border-green-200',
+  error: 'text-red-600 bg-red-50 border-red-200',
+  warning: 'text-yellow-600 bg-yellow-50 border-yellow-200',
+  info: 'text-blue-600 bg-blue-50 border-blue-200',
+  loading: 'text-purple-600 bg-purple-50 border-purple-200'
+}
+
+export const FeedbackMessage: React.FC<FeedbackMessageProps> = ({
+  type,
+  title,
+  message,
+  actions,
+  onDismiss,
+  autoHide = true,
+  duration = 5000
+}) => {
+  const Icon = iconMap[type]
+
+  React.useEffect(() => {
+    if (autoHide && onDismiss && type !== 'loading') {
+      const timer = setTimeout(onDismiss, duration)
+      return () => clearTimeout(timer)
+    }
+  }, [autoHide, onDismiss, duration, type])
+
+  return (
+    <div className={`feedback-message ${colorMap[type]}`}>
+      <div className="feedback-content">
+        <Icon className={`feedback-icon ${type === 'loading' ? 'animate-spin' : ''}`} />
+
+        <div className="feedback-text">
+          {title && <h3 className="feedback-title">{title}</h3>}
+          <p className="feedback-message-text">{message}</p>
+          {actions && <div className="feedback-actions">{actions}</div>}
+        </div>
+
+        {onDismiss && type !== 'loading' && (
+          <button onClick={onDismiss} className="feedback-dismiss">
+            <XCircle className="w-5 h-5" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// États vides
+interface EmptyStateProps {
+  icon?: React.ReactNode
+  title: string
+  description: string
+  action?: React.ReactNode
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  icon,
+  title,
+  description,
+  action
+}) => (
+  <div className="empty-state">
+    {icon && <div className="empty-state-icon">{icon}</div>}
+    <h3 className="empty-state-title">{title}</h3>
+    <p className="empty-state-description">{description}</p>
+    {action && <div className="empty-state-action">{action}</div>}
+  </div>
+)

--- a/src/components/UI/LoadingStates.tsx
+++ b/src/components/UI/LoadingStates.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+
+interface LoadingSpinnerProps {
+  size?: 'small' | 'medium' | 'large'
+  color?: string
+}
+
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+  size = 'medium',
+  color = 'currentColor'
+}) => {
+  const sizeClasses = {
+    small: 'w-4 h-4',
+    medium: 'w-8 h-8',
+    large: 'w-12 h-12'
+  }
+
+  return (
+    <div className={`loading-spinner ${sizeClasses[size]}`}>
+      <svg className="animate-spin" fill="none" viewBox="0 0 24 24" style={{ color }}>
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        />
+      </svg>
+    </div>
+  )
+}
+
+interface ProgressBarProps {
+  progress: number
+  showLabel?: boolean
+  label?: string
+  color?: string
+}
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({
+  progress,
+  showLabel = true,
+  label,
+  color = '#6366f1'
+}) => {
+  return (
+    <div className="progress-container">
+      {showLabel && (
+        <div className="progress-header">
+          <span className="progress-label">{label || 'Progression'}</span>
+          <span className="progress-percentage">{Math.round(progress)}%</span>
+        </div>
+      )}
+
+      <div className="progress-track">
+        <div
+          className="progress-bar-fill"
+          style={{
+            width: `${Math.min(100, Math.max(0, progress))}%`,
+            backgroundColor: color
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface SkeletonProps {
+  width?: string
+  height?: string
+  className?: string
+}
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  width = '100%',
+  height = '1rem',
+  className = ''
+}) => {
+  return (
+    <div className={`skeleton ${className}`} style={{ width, height }} />
+  )
+}
+
+export const CardSkeleton: React.FC = () => (
+  <div className="card-skeleton">
+    <Skeleton height="200px" className="mb-4" />
+    <Skeleton height="1.5rem" width="70%" className="mb-2" />
+    <Skeleton height="1rem" width="50%" className="mb-4" />
+    <div className="flex gap-2">
+      <Skeleton height="2rem" width="80px" />
+      <Skeleton height="2rem" width="80px" />
+    </div>
+  </div>
+)

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import "./styles/navigation.css";
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -1,0 +1,406 @@
+/* Navigation principale */
+.main-navigation {
+  width: 280px;
+  height: 100vh;
+  background: linear-gradient(180deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  overflow-y: auto;
+}
+
+.nav-container {
+  padding: 24px 16px;
+}
+
+.nav-header {
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.logo-text {
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: block;
+}
+
+.logo-subtitle {
+  font-size: 0.875rem;
+  opacity: 0.8;
+}
+
+.nav-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: none;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: 100%;
+}
+
+.nav-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateX(4px);
+}
+
+.nav-item.active {
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.nav-item-icon {
+  flex-shrink: 0;
+}
+
+.nav-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.nav-item-label {
+  font-weight: 500;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.nav-item-description {
+  font-size: 0.75rem;
+  opacity: 0.8;
+  display: block;
+}
+
+.nav-item-badge {
+  background: rgba(255, 255, 255, 0.3);
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.nav-progress {
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  padding-top: 20px;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+  margin-bottom: 8px;
+}
+
+.progress-fill {
+  height: 100%;
+  background: white;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.progress-text {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+/* Breadcrumb */
+.breadcrumb {
+  margin-bottom: 24px;
+}
+
+.breadcrumb-list {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.breadcrumb-link {
+  color: #6b7280;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s ease;
+}
+
+.breadcrumb-link:hover {
+  color: #374151;
+}
+
+.breadcrumb-current {
+  color: #111827;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.breadcrumb-separator {
+  color: #9ca3af;
+}
+
+/* Layout responsive */
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.mobile-header {
+  display: none;
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 16px;
+  position: sticky;
+  top: 0;
+  z-index: 40;
+}
+
+.mobile-header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mobile-logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #667eea;
+}
+
+.mobile-menu-toggle {
+  background: none;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+}
+
+.mobile-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 45;
+}
+
+.sidebar {
+  flex-shrink: 0;
+}
+
+.main-content {
+  flex: 1;
+  background: #f9fafb;
+  overflow: hidden;
+}
+
+.content-header {
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 16px 24px;
+}
+
+.content-body {
+  padding: 24px;
+  height: calc(100vh - 120px);
+  overflow-y: auto;
+}
+
+/* États de chargement */
+.loading-spinner {
+  display: inline-block;
+}
+
+.progress-container {
+  width: 100%;
+}
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.progress-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.progress-percentage {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.progress-track {
+  width: 100%;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: #6366f1;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+  border-radius: 4px;
+}
+
+@keyframes skeleton-loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.card-skeleton {
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+}
+
+/* Feedback messages */
+.feedback-message {
+  border: 1px solid;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.feedback-content {
+  display: flex;
+  gap: 12px;
+}
+
+.feedback-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.feedback-text {
+  flex: 1;
+}
+
+.feedback-title {
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  font-size: 0.875rem;
+}
+
+.feedback-message-text {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.feedback-actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+}
+
+.feedback-dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  margin-top: -4px;
+}
+
+/* Empty states */
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+}
+
+.empty-state-icon {
+  margin-bottom: 16px;
+  color: #9ca3af;
+}
+
+.empty-state-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 8px 0;
+}
+
+.empty-state-description {
+  color: #6b7280;
+  margin: 0 0 24px 0;
+}
+
+.empty-state-action {
+  display: flex;
+  justify-content: center;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .mobile-header {
+    display: block;
+  }
+  
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 50;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+  }
+  
+  .sidebar.mobile-open {
+    transform: translateX(0);
+  }
+  
+  .mobile-overlay {
+    display: block;
+  }
+  
+  .main-content {
+    width: 100%;
+  }
+  
+  .content-body {
+    padding: 16px;
+    height: calc(100vh - 140px);
+  }
+  
+  .nav-item-description {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .content-body {
+    padding: 12px;
+  }
+  
+  .breadcrumb-item {
+    font-size: 0.75rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- create MainNavigation and Breadcrumb components
- provide LoadingStates and FeedbackStates utilities
- implement AppLayout with mobile sidebar
- add global navigation styles
- integrate navigation CSS into global styles

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a17ec7f5c832daa912961e942e7be