### PR TITLE
Ajout et intégration de tests unitaires robustes sur tous les parseurs clés (OIC, EDN…), avec blocage du merge en cas d’échec (CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ Issues and pull requests are welcome. Please open an issue first to discuss any 
 ## Contact
 
 For any question about this backend, please contact the original maintainers or open an issue on the repository.
+
+## Parser Test Guide
+
+Critical data parsers such as `parseOICContent` and `EDNItemParser` are covered by Jest tests located in the `test/` directory. To add a new parser test:
+
+1. Create a `*.test.ts` file under `test/`.
+2. Import the parser function using a relative path.
+3. Provide sample input objects that mimic the structure returned by the external APIs.
+4. Assert on the parsed output and edge cases (invalid input, missing fields, etc.).
+
+Run `pnpm test` locally or push a branch to trigger the CI workflow which blocks merges if any test fails.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,11 @@ export default {
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
   testPathIgnorePatterns: ["migrationHelpers.test.ts"],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.app.json'
+    }
+  },
   collectCoverage: true,
   coverageDirectory: 'coverage',
 };

--- a/test/ednItemParser.test.ts
+++ b/test/ednItemParser.test.ts
@@ -1,0 +1,56 @@
+import EDNItemParser from '../src/parsers/ednItemParser';
+import { createEmptyItemEDN } from '../src/schemas/itemEDNSchema';
+
+describe('EDNItemParser', () => {
+  const baseItem = createEmptyItemEDN('IC-001', 'Test Item', 'organisation_systeme');
+  baseItem.content.rang_a.competences.push({
+    competence_id: 'COMP_A',
+    concept: 'Concept A',
+    definition: 'Definition A',
+    exemple: 'Example A',
+    piege: 'Piege A',
+    mnemo: 'Mnemo A',
+    subtilite: 'Subtilite A',
+    application: 'Application A',
+    vigilance: 'Vigilance A',
+    paroles_chantables: ['Parole A']
+  });
+  baseItem.content.rang_b.competences.push({
+    competence_id: 'COMP_B',
+    concept: 'Concept B',
+    definition: 'Definition B',
+    exemple: 'Example B',
+    piege: 'Piege B',
+    mnemo: 'Mnemo B',
+    subtilite: 'Subtilite B',
+    application: 'Application B',
+    vigilance: 'Vigilance B',
+    paroles_chantables: []
+  });
+
+  it('parses a v2 item correctly', () => {
+    const parsed = EDNItemParser.parseItemV2(baseItem, '123');
+    expect(parsed.id).toBe('123');
+    expect(parsed.item_code).toBe('IC-001');
+    expect(parsed.tableau_rang_a.lignes.length).toBe(1);
+    expect(parsed.tableau_rang_b.lignes.length).toBe(1);
+    expect(parsed.paroles_musicales.length).toBe(1);
+    expect(parsed.scene_immersive.type).toBe('medical_scenario');
+    expect(parsed.quiz_questions.questions.length).toBeGreaterThan(0);
+  });
+
+  it('parseAnyItem falls back to legacy parser', () => {
+    const legacy = {
+      item_code: 'IC-002',
+      title: 'Legacy',
+      slug: 'legacy-item',
+      tableau_rang_a: { theme: 'A', lignes: [], colonnes: [] },
+      tableau_rang_b: { theme: 'B', lignes: [], colonnes: [] },
+      paroles_musicales: []
+    };
+    const parsed = EDNItemParser.parseAnyItem(legacy, 'legacy');
+    expect(parsed.id).toBe('legacy');
+    expect(parsed.item_code).toBe('IC-002');
+    expect(parsed.tableau_rang_a.theme).toBe('A');
+  });
+});

--- a/test/oicParser.test.ts
+++ b/test/oicParser.test.ts
@@ -1,0 +1,56 @@
+import { parseOICContent } from '../supabase/functions/extract-edn-objectifs/oic-parser';
+
+describe('parseOICContent', () => {
+  it('parses a valid OIC page', () => {
+    const page = {
+      title: 'OIC-001-05-A-01',
+      revisions: [
+        { slots: { main: { content: "| Intitulé = Test Intitule | Description = Exemple de description" } } }
+      ]
+    };
+    const result = parseOICContent(page);
+    expect(result).toBeTruthy();
+    expect(result!.objectif_id).toBe('OIC-001-05-A-01');
+    expect(result!.intitule).toBe('Test Intitule');
+    expect(result!.rubrique).toBe('Pharmacologie');
+    expect(result!.ordre).toBe(1);
+  });
+
+  it('returns null when title does not match pattern', () => {
+    const page = {
+      title: 'Invalid-Title',
+      revisions: [{ slots: { main: { content: '| something' } } }]
+    };
+    expect(parseOICContent(page)).toBeNull();
+  });
+
+  it('handles old revision format', () => {
+    const page = {
+      title: 'OIC-002-06-B-02',
+      revisions: [
+        { '*': "| Intitulé = Old Format" }
+      ]
+    } as any;
+    const res = parseOICContent(page);
+    expect(res).toBeTruthy();
+    expect(res!.item_parent).toBe('002');
+    expect(res!.rang).toBe('B');
+    expect(res!.ordre).toBe(2);
+  });
+
+  it('returns null when content is missing', () => {
+    const page = { title: 'OIC-001-05-A-01', revisions: [{}] };
+    expect(parseOICContent(page)).toBeNull();
+  });
+
+  it('uses default description when none found', () => {
+    const page = {
+      title: 'OIC-003-01-A-03',
+      revisions: [
+        { slots: { main: { content: "| Intitulé = My Title" } } }
+      ]
+    };
+    const res = parseOICContent(page)!;
+    expect(res.description).toBe(`Description de l'objectif OIC-003-01-A-03`);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for OIC parser
- add unit tests for EDN item parser
- document how to write parser tests in README
- configure ts-jest to use project tsconfig

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688289c787d8832da1f435a4fcd3a4d4