### PR TITLE
Automatisation et fiabilisation des tests API (REST), robustesse et gestion des erreurs sur tout le back-end MED-MNG

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
+  setupFiles: ['<rootDir>/test/testSetup.ts'],
   testPathIgnorePatterns: ["migrationHelpers.test.ts"],
   collectCoverage: true,
   coverageDirectory: 'coverage',

--- a/supabase/functions/med-mng-api/routes/songs.ts
+++ b/supabase/functions/med-mng-api/routes/songs.ts
@@ -1,6 +1,8 @@
 
 import { corsHeaders, CreateSongRequest } from '../types.ts';
 
+declare const Deno: { env: { get(key: string): string | undefined } };
+
 export async function handleSongs(req: Request, supabase: any, path: string) {
   // POST /songs - Create a new song
   if (path === '/songs' && req.method === 'POST') {

--- a/test/api.integration.test.ts
+++ b/test/api.integration.test.ts
@@ -1,0 +1,61 @@
+import { handleSongs } from '../supabase/functions/med-mng-api/routes/songs.ts';
+import { handleQuota } from '../supabase/functions/med-mng-api/routes/quota.ts';
+
+const createRequest = (path: string, method: string, body?: any) =>
+  new Request(`https://example.com${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+describe('med-mng-api route handlers', () => {
+  beforeAll(() => {
+    // Provide Deno.env.get in Node tests
+    // @ts-ignore
+    global.Deno = { env: { get: (k: string) => process.env[k] } };
+  });
+
+  test('POST /songs returns 403 when quota insufficient', async () => {
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({ data: 0 }),
+      from: jest.fn(),
+    };
+    const req = createRequest('/songs', 'POST', {
+      title: 'Test',
+      suno_audio_id: '123',
+    });
+    const res = await handleSongs(req, supabase, '/songs');
+    expect(res?.status).toBe(403);
+  });
+
+  test('POST /songs creates song when quota ok', async () => {
+    const insertMock = jest.fn().mockReturnValue({
+      select: () => ({
+        single: () => Promise.resolve({ data: { id: '1' }, error: null }),
+      }),
+    });
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({ data: 2 }),
+      from: jest.fn(() => ({ insert: insertMock })),
+    };
+    const req = createRequest('/songs', 'POST', {
+      title: 'Demo',
+      suno_audio_id: 'abc',
+    });
+    const res = await handleSongs(req, supabase, '/songs');
+    expect(res?.status).toBe(200);
+    const body = await res?.json();
+    expect(body.id).toBe('1');
+  });
+
+  test('GET /quota returns remaining credits', async () => {
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({ data: 5 }),
+    };
+    const req = createRequest('/quota', 'GET');
+    const res = await handleQuota(req, supabase, '/quota');
+    expect(res?.status).toBe(200);
+    const body = await res?.json();
+    expect(body.remaining_credits).toBe(5);
+  });
+});

--- a/test/global.d.ts
+++ b/test/global.d.ts
@@ -1,0 +1,2 @@
+declare var Deno: { env: { get(key: string): string | undefined } };
+export {};

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -1,0 +1,3 @@
+// Polyfill Deno.env.get for modules expecting Deno runtime
+(global as any).Deno = { env: { get: (key: string) => process.env[key] } };
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,12 @@
     "allowJs": true,
     "noUnusedLocals": false,
     "strictNullChecks": false,
-    "esModuleInterop": true
-  }
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": [
+    "src",
+    "supabase",
+    "test/global.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add integration tests for API route handlers
- support Deno env in tests via setup file
- allow importing `.ts` extensions and include test typings
- adjust songs route typings for Node tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68828ae145e8832db24f50f0a99977d9