### PR TITLE
Refonte de la gestion des erreurs sur tout le stack (back-end & front) pour robustesse, traçabilité et expérience utilisateur sans fail silencieux

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ pnpm install
 cp .env.example .env
 ```
 
+## Error Handling
+
+All backend endpoints must return explicit errors with the correct HTTP status code. See [docs/errors.md](docs/errors.md) for the full policy.
+
 3. Start Supabase locally
 
 ```bash

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,25 @@
+# Error Handling Policy
+
+This project aims to avoid silent failures across the stack. Any error occurring in the backend must be logged and an explicit HTTP response returned to the client.
+
+## Backend
+- Use the `log` utility to log errors with a timestamp and severity.
+- API routes should return appropriate HTTP status codes (400 for bad requests, 401 for unauthenticated, 403 for forbidden, 404 for missing resources, 429 for quota issues, 500 for server errors).
+- Avoid empty `catch` blocks. When an unexpected error occurs, log it and return a JSON payload such as `{ "error": "Message" }`.
+
+## Frontend
+- Display API error messages to users via toast or alert components.
+- Capture unexpected UI exceptions and send them to the logger or monitoring system.
+
+## Example
+```ts
+try {
+  const data = await fetchData();
+  return new Response(JSON.stringify({ data }), { status: 200 });
+} catch (e) {
+  log('error', 'fetchData failed', e);
+  return new Response(JSON.stringify({ error: 'Erreur lors de la récupération des données' }), { status: 500 });
+}
+```
+
+Use this document as a guideline for future contributors.

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { log } from '../../supabase/functions/med-mng-api/logger';
 
 export function errorHandler(
   err: unknown,
@@ -6,6 +7,6 @@ export function errorHandler(
   res: Response,
   _next: NextFunction
 ) {
-  console.error(err);
+  log('error', 'Express error', err);
   res.status(500).json({ error: 'Internal Server Error' });
 }

--- a/supabase/functions/med-mng-api/index.ts
+++ b/supabase/functions/med-mng-api/index.ts
@@ -8,6 +8,7 @@ import { handleLibrary } from './routes/library.ts';
 import { handleQuota } from './routes/quota.ts';
 import { handleVerify } from './routes/verify.ts';
 import { handleComplete } from './routes/complete.ts';
+import { log } from './logger.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
@@ -48,7 +49,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('API Error:', error);
+    log('error', 'API Error', error);
     return new Response(
       JSON.stringify({ error: error.message }),
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }

--- a/supabase/functions/med-mng-api/logger.ts
+++ b/supabase/functions/med-mng-api/logger.ts
@@ -1,0 +1,13 @@
+export const log = (
+  level: 'info' | 'warn' | 'error',
+  message: string,
+  meta?: unknown
+) => {
+  const timestamp = new Date().toISOString();
+  const base = `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+  if (meta) {
+    console[level === 'error' ? 'error' : 'log'](base, meta);
+  } else {
+    console[level === 'error' ? 'error' : 'log'](base);
+  }
+};

--- a/supabase/functions/med-mng-api/routes/songs.ts
+++ b/supabase/functions/med-mng-api/routes/songs.ts
@@ -1,5 +1,6 @@
 
 import { corsHeaders, CreateSongRequest } from '../types.ts';
+import { log } from '../logger.ts';
 
 export async function handleSongs(req: Request, supabase: any, path: string) {
   // POST /songs - Create a new song
@@ -131,7 +132,11 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
           );
         }
       } catch (error) {
-        console.error('Error fetching lyrics:', error);
+        log('error', 'Error fetching lyrics', error);
+        return new Response(
+          JSON.stringify({ error: 'Erreur récupération paroles' }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- add a small logger helper for edge functions
- return explicit error when fetching lyrics fails
- log API errors using the new helper
- log Express errors in middleware
- document the error handling policy
- mention the new doc in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828b1fa9f0832d81a9d5befcaeb893