### PR TITLE
Audit complet et sécurisation des RLS

### DIFF
--- a/docs/rls.md
+++ b/docs/rls.md
@@ -1,0 +1,18 @@
+# Row Level Security Policies
+
+This document lists the RLS configuration for sensitive tables. Each table has policies limiting access to the appropriate roles and enabling full access for `service_role`.
+
+## edn_items_immersive
+- **Public**: read-only access.
+- **service_role**: full access to bypass restrictions.
+
+## med_mng_items and related tables
+Tables: `med_mng_items`, `comic_panels`, `roman_versions`, `music_tracks`, `quiz_questions`, `audit_logs`.
+- **Users**: can manage rows where `user_id` matches their auth id (except `audit_logs` which is service-only).
+- **service_role**: full access for backend operations.
+
+## oic_competences & oic_extraction_progress
+- **Public**: read-only access to `oic_competences`.
+- **service_role**: full access to both tables.
+
+The migration `20250801000000-12ffeeb7-77f2-46a2-8bdc-1338b6c22781.sql` enforces these policies and ensures RLS is enabled on all relevant tables.

--- a/scripts/auditRls.ts
+++ b/scripts/auditRls.ts
@@ -1,0 +1,25 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL as string;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+export async function listPolicies() {
+  if (!url || !key) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  const supabase = createClient(url, key, { auth: { persistSession: false } });
+  const { data, error } = await supabase.rpc('list_rls_policies');
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data;
+}
+
+if (require.main === module) {
+  listPolicies()
+    .then((data) => console.table(data))
+    .catch((err) => {
+      console.error('Error fetching policies', err.message);
+      process.exit(1);
+    });
+}

--- a/supabase/migrations/20250801000000-12ffeeb7-77f2-46a2-8bdc-1338b6c22781.sql
+++ b/supabase/migrations/20250801000000-12ffeeb7-77f2-46a2-8bdc-1338b6c22781.sql
@@ -1,0 +1,51 @@
+-- Audit & fix RLS policies for sensitive tables
+
+-- Add RLS policies for edn_items_immersive
+ALTER TABLE public.edn_items_immersive ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "public read" ON public.edn_items_immersive;
+CREATE POLICY "Public can read EDN items"
+  ON public.edn_items_immersive
+  FOR SELECT
+  USING (true);
+
+-- Service role full access
+DROP POLICY IF EXISTS "service role all" ON public.edn_items_immersive;
+CREATE POLICY "Service role full access" 
+  ON public.edn_items_immersive
+  FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+-- Add RLS policies for med_mng_items and related tables
+DO $$
+DECLARE
+  tbl TEXT;
+BEGIN
+  FOR tbl IN SELECT unnest(ARRAY['med_mng_items','comic_panels','roman_versions','music_tracks','quiz_questions','audit_logs'])
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY;', tbl);
+    EXECUTE format('DROP POLICY IF EXISTS "Service role full access" ON public.%I;', tbl);
+    EXECUTE format('CREATE POLICY "Service role full access" ON public.%I FOR ALL USING (auth.jwt() ->> ''role'' = ''service_role'');', tbl);
+    EXECUTE format('DROP POLICY IF EXISTS "Users manage own" ON public.%I;', tbl);
+    IF tbl <> 'audit_logs' THEN
+      EXECUTE format('CREATE POLICY "Users manage own" ON public.%I FOR ALL USING (auth.uid() = user_id);', tbl);
+    END IF;
+  END LOOP;
+END$$;
+
+-- Secure OIC tables
+ALTER TABLE public.oic_competences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.oic_extraction_progress ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Allow service role to manage oic_competences" ON public.oic_competences;
+CREATE POLICY "Service role manages oic_competences" ON public.oic_competences FOR ALL USING (auth.jwt() ->> 'role' = 'service_role');
+DROP POLICY IF EXISTS "Allow service role to manage oic_extraction_progress" ON public.oic_extraction_progress;
+CREATE POLICY "Service role manages oic_extraction_progress" ON public.oic_extraction_progress FOR ALL USING (auth.jwt() ->> 'role' = 'service_role');
+
+-- Helper function to list current RLS policies
+CREATE OR REPLACE FUNCTION public.list_rls_policies()
+RETURNS TABLE(table_name text, policy_name text, command text, roles text, using_expression text)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT tablename, policyname, cmd, roles, COALESCE(using_clause, 'n/a')
+  FROM pg_policies
+  WHERE schemaname = 'public';
+$$;

--- a/test/auditRlsScript.test.ts
+++ b/test/auditRlsScript.test.ts
@@ -1,0 +1,5 @@
+import { listPolicies } from '../scripts/auditRls';
+
+test('throws when env vars are missing', async () => {
+  await expect(listPolicies()).rejects.toThrow('Missing SUPABASE_URL');
+});


### PR DESCRIPTION
## Summary
- add missing RLS policies for sensitive tables via new migration
- provide helper function `list_rls_policies`
- document RLS strategy in `docs/rls.md`
- add script `scripts/auditRls.ts` to list policies
- include basic test ensuring script fails without env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828b7b1f34832da8671d7541c78483