### PR TITLE
Implement incident alert service

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { log } from '../../supabase/functions/med-mng-api/logger';
+import { notifyIncident } from '../services/alertService';
 
 export function errorHandler(
   err: unknown,
@@ -8,5 +9,10 @@ export function errorHandler(
   _next: NextFunction
 ) {
   log('error', 'Express error', err);
+  void notifyIncident({
+    type: 'BACKEND_ERROR',
+    message: err instanceof Error ? err.message : 'Unknown error',
+    details: err,
+  });
   res.status(500).json({ error: 'Internal Server Error' });
 }

--- a/src/services/alertService.ts
+++ b/src/services/alertService.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+export type IncidentType =
+  | 'EXTRACTION_FAILURE'
+  | 'PAYMENT_FAILURE'
+  | 'BACKEND_ERROR'
+  | 'QUOTA_EXCEEDED'
+  | 'SUPABASE_DOWN';
+
+export interface Incident {
+  type: IncidentType;
+  message: string;
+  details?: unknown;
+}
+
+const discordWebhook = process.env.DISCORD_WEBHOOK_URL;
+const slackWebhook = process.env.SLACK_WEBHOOK_URL;
+
+export async function notifyIncident(incident: Incident): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+  const text = `[${incident.type}] ${incident.message}`;
+
+  if (discordWebhook) {
+    tasks.push(
+      axios
+        .post(discordWebhook, { content: text })
+        .catch((err) => console.error('Discord alert failed', err))
+    );
+  }
+
+  if (slackWebhook) {
+    tasks.push(
+      axios
+        .post(slackWebhook, { text, incident })
+        .catch((err) => console.error('Slack alert failed', err))
+    );
+  }
+
+  if (tasks.length) {
+    await Promise.all(tasks);
+  }
+}

--- a/test/errorHandler.test.ts
+++ b/test/errorHandler.test.ts
@@ -1,0 +1,21 @@
+import request from 'supertest';
+import express from 'express';
+import { errorHandler } from '../src/middleware/errorHandler';
+import { notifyIncident } from '../src/services/alertService';
+
+jest.mock('../src/services/alertService', () => ({ notifyIncident: jest.fn() }));
+
+const app = express();
+app.get('/boom', () => {
+  throw new Error('boom');
+});
+app.use(errorHandler);
+
+describe('errorHandler', () => {
+  it('calls notifyIncident on error', async () => {
+    await request(app).get('/boom');
+    expect(notifyIncident).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'BACKEND_ERROR' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add alert service for Discord/Slack notifications
- trigger alerts from Express error handler
- test error handler sends incident alert

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68828e856cbc832d8bdbef20e6c2e491