### PR TITLE
Add Docker Compose for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ docker build -t med-mng .
 docker run -p 3000:3000 med-mng
 ```
 
+#### Docker Compose
+
+```bash
+docker compose up --build
+```
+
+Scripts for database management are available in `scripts/`:
+- `init.sh` applies migrations
+- `reset-db.sh` drops and recreates the DB
+- `seed.sh` inserts test data
+
+
 ## Key Endpoints
 
 The main API is served from the `med-mng-api` edge function.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: medmng
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  backend:
+    build: .
+    environment:
+      DB_HOST: db
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: medmng
+      SUPABASE_URL: http://supabase-mock:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - supabase-mock
+
+  supabase-mock:
+    image: supabase/cli:latest
+    command: start
+    ports:
+      - "8000:8000"
+volumes:
+  db_data:

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply SQL migrations to the local database
+for file in supabase/migrations/*.sql; do
+  echo "Applying $file"
+  docker compose exec -T db psql -U postgres -d medmng -f /dev/stdin < "$file"
+done
+
+echo "Migrations applied"

--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Resetting database..."
+# Drop and recreate the database
+docker compose exec -T db psql -U postgres -c 'DROP DATABASE IF EXISTS medmng;'
+docker compose exec -T db psql -U postgres -c 'CREATE DATABASE medmng;'
+
+# Reapply migrations
+./scripts/init.sh

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm test

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Example seed script using existing TypeScript utility
+# Requires the backend container to be running
+
+docker compose exec backend node --loader ts-node/esm scripts/addIC10Item.ts


### PR DESCRIPTION
## Summary
- create `docker-compose.yml` with backend, Postgres and Supabase mock services
- add helper scripts (`init.sh`, `reset-db.sh`, `seed.sh`, `run-tests.sh`)
- document Docker Compose usage in README

## Testing
- `pnpm test --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68828f5f7250832d9ce8aa1afa096f84