### PR TITLE
Add security headers and basic rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ The main API is served from the `med-mng-api` edge function.
 
 All routes require Supabase authentication and return JSON.
 
+## API Security
+
+Security headers such as **Content-Security-Policy**, **Strict-Transport-Security**, **X-Frame-Options** and others are automatically applied to every response. The edge functions merge these headers with CORS settings and the Express server uses Helmet.
+
+A lightweight IP rate limiter caps requests to 60 per minute on the edge API and the Node server. Modify the limits in `supabase/functions/med-mng-api/index.ts` or `src/index.ts` if needed.
+
 ## Contributing
 
 Issues and pull requests are welcome. Please open an issue first to discuss any major changes.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "dompurify": "^3.2.6",
     "embla-carousel-react": "^8.3.0",
     "express": "^4.19.2",
+    "helmet": "^7.1.2",
+    "express-rate-limit": "^7.1.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.56.2
         version: 5.82.0(react@18.3.1)
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/react-window':
         specifier: ^1.8.8
         version: 1.8.8
@@ -116,12 +119,21 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
       embla-carousel-react:
         specifier: ^8.3.0
         version: 8.6.0(react@18.3.1)
       express:
         specifier: ^4.19.2
         version: 4.21.2
+      express-rate-limit:
+        specifier: ^7.1.0
+        version: 7.5.1(express@4.21.2)
+      helmet:
+        specifier: ^7.1.2
+        version: 7.2.0
       input-otp:
         specifier: ^1.2.4
         version: 1.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1837,6 +1849,10 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1880,6 +1896,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2438,6 +2457,9 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2636,6 +2658,12 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -2838,6 +2866,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  helmet@7.2.0:
+    resolution: {integrity: sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==}
+    engines: {node: '>=16.0.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -5810,6 +5842,10 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.2.6
+
   '@types/estree@1.0.8': {}
 
   '@types/graceful-fs@4.1.9':
@@ -5855,6 +5891,9 @@ snapshots:
       csstype: 3.1.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -6438,6 +6477,10 @@ snapshots:
       '@babel/runtime': 7.27.6
       csstype: 3.1.3
 
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6688,6 +6731,10 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  express-rate-limit@7.5.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -6931,6 +6978,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@7.2.0: {}
 
   html-escaper@2.0.2: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,22 @@
 import express from 'express';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import { healthCheck } from './controllers/healthController';
 import { errorHandler } from './middleware/errorHandler';
 
 const app = express();
+
+// Security headers
+app.use(helmet());
+
+// Basic rate limiting
+const limiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+app.use(limiter);
 const port = import.meta.env.PORT || 3000;
 
 app.get('/health', healthCheck);

--- a/supabase/functions/med-mng-api/index.ts
+++ b/supabase/functions/med-mng-api/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from './types.ts';
+import { corsHeaders, securityHeaders } from './types.ts';
 import { validateAuth } from './auth.ts';
 import { handleSubscriptions } from './routes/subscriptions.ts';
 import { handleSongs } from './routes/songs.ts';
@@ -10,9 +10,31 @@ import { handleVerify } from './routes/verify.ts';
 import { handleComplete } from './routes/complete.ts';
 import { log } from './logger.ts';
 
+const rateMap = new Map<string, { count: number; reset: number }>();
+
+function checkRate(key: string, limit: number, windowMs: number) {
+  const now = Date.now();
+  const entry = rateMap.get(key);
+  if (entry && now < entry.reset) {
+    if (entry.count >= limit) return false;
+    entry.count++;
+    return true;
+  }
+  rateMap.set(key, { count: 1, reset: now + windowMs });
+  return true;
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+    return new Response(null, { headers: { ...corsHeaders, ...securityHeaders } });
+  }
+
+  const ip = req.headers.get('x-forwarded-for') ?? 'anon';
+  if (!checkRate(ip, 60, 60_000)) {
+    return new Response(
+      JSON.stringify({ error: 'Too Many Requests' }),
+      { status: 429, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
+    );
   }
 
   const { error, supabase, user } = await validateAuth(req);
@@ -45,14 +67,14 @@ serve(async (req) => {
 
     return new Response(
       JSON.stringify({ error: 'Route not found' }),
-      { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { status: 404, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
 
   } catch (error) {
     log('error', 'API Error', error);
     return new Response(
       JSON.stringify({ error: error.message }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });

--- a/supabase/functions/med-mng-api/routes/complete.ts
+++ b/supabase/functions/med-mng-api/routes/complete.ts
@@ -1,4 +1,4 @@
-import { corsHeaders } from '../types.ts';
+import { corsHeaders, securityHeaders } from '../types.ts';
 import { verifyItem } from './verify.ts';
 
 export async function handleComplete(req: Request, supabase: any, path: string) {
@@ -7,7 +7,7 @@ export async function handleComplete(req: Request, supabase: any, path: string) 
     const report = await completeItem(supabase, itemId);
     return new Response(
       JSON.stringify(report),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -24,7 +24,7 @@ export async function handleComplete(req: Request, supabase: any, path: string) 
 
     return new Response(
       JSON.stringify(results),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 

--- a/supabase/functions/med-mng-api/routes/library.ts
+++ b/supabase/functions/med-mng-api/routes/library.ts
@@ -1,5 +1,5 @@
 
-import { corsHeaders, AddToLibraryRequest } from '../types.ts';
+import { corsHeaders, securityHeaders, AddToLibraryRequest } from '../types.ts';
 
 export async function handleLibrary(req: Request, supabase: any, path: string, url: URL) {
   // POST /library - Add to library
@@ -12,7 +12,7 @@ export async function handleLibrary(req: Request, supabase: any, path: string, u
 
     return new Response(
       JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -26,7 +26,7 @@ export async function handleLibrary(req: Request, supabase: any, path: string, u
 
     return new Response(
       JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -45,7 +45,7 @@ export async function handleLibrary(req: Request, supabase: any, path: string, u
 
     return new Response(
       JSON.stringify(data),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 

--- a/supabase/functions/med-mng-api/routes/quota.ts
+++ b/supabase/functions/med-mng-api/routes/quota.ts
@@ -1,5 +1,5 @@
 
-import { corsHeaders } from '../types.ts';
+import { corsHeaders, securityHeaders } from '../types.ts';
 
 export async function handleQuota(req: Request, supabase: any, path: string) {
   // GET /quota - Get remaining quota
@@ -10,7 +10,7 @@ export async function handleQuota(req: Request, supabase: any, path: string) {
 
     return new Response(
       JSON.stringify({ remaining_credits: quota || 0 }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 

--- a/supabase/functions/med-mng-api/routes/songs.ts
+++ b/supabase/functions/med-mng-api/routes/songs.ts
@@ -1,5 +1,5 @@
 
-import { corsHeaders, CreateSongRequest } from '../types.ts';
+import { corsHeaders, securityHeaders, CreateSongRequest } from '../types.ts';
 import { log } from '../logger.ts';
 
 declare const Deno: { env: { get(key: string): string | undefined } };
@@ -15,7 +15,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
     if (!quotaData || quotaData <= 0) {
       return new Response(
         JSON.stringify({ error: 'Quota insuffisant' }),
-        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        { status: 403, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -30,7 +30,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
 
     return new Response(
       JSON.stringify(data),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -47,7 +47,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
     if (error || !song) {
       return new Response(
         JSON.stringify({ error: 'Song not found' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        { status: 404, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -62,6 +62,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
 
     const responseHeaders = {
       ...corsHeaders,
+      ...securityHeaders,
       'Content-Type': 'audio/mpeg',
       'Content-Disposition': 'inline',
       'Cache-Control': 'private, max-age=300',
@@ -89,7 +90,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
 
     return new Response(
       JSON.stringify({ liked: isLiked }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -106,7 +107,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
     if (error || !song) {
       return new Response(
         JSON.stringify({ error: 'Song not found' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        { status: 404, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -130,21 +131,21 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
           
           return new Response(
             JSON.stringify(lyricsData),
-            { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+            { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
           );
         }
       } catch (error) {
         log('error', 'Error fetching lyrics', error);
         return new Response(
           JSON.stringify({ error: 'Erreur récupération paroles' }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          { status: 500, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
         );
       }
     }
 
     return new Response(
       JSON.stringify(song.lyrics || {}),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 

--- a/supabase/functions/med-mng-api/routes/subscriptions.ts
+++ b/supabase/functions/med-mng-api/routes/subscriptions.ts
@@ -1,5 +1,5 @@
 
-import { corsHeaders, CreateSubscriptionRequest } from '../types.ts';
+import { corsHeaders, securityHeaders, CreateSubscriptionRequest } from '../types.ts';
 
 export async function handleSubscriptions(req: Request, supabase: any) {
   if (req.method === 'POST') {
@@ -15,7 +15,7 @@ export async function handleSubscriptions(req: Request, supabase: any) {
 
     return new Response(
       JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 

--- a/supabase/functions/med-mng-api/routes/verify.ts
+++ b/supabase/functions/med-mng-api/routes/verify.ts
@@ -1,4 +1,4 @@
-import { corsHeaders } from '../types.ts';
+import { corsHeaders, securityHeaders } from '../types.ts';
 
 export async function handleVerify(req: Request, supabase: any, path: string) {
   // GET /verify-item/:id
@@ -7,7 +7,7 @@ export async function handleVerify(req: Request, supabase: any, path: string) {
     const report = await verifyItem(supabase, itemId);
     return new Response(
       JSON.stringify(report),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -25,7 +25,7 @@ export async function handleVerify(req: Request, supabase: any, path: string) {
 
     return new Response(
       JSON.stringify(results),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
     );
   }
 

--- a/supabase/functions/med-mng-api/types.ts
+++ b/supabase/functions/med-mng-api/types.ts
@@ -19,3 +19,12 @@ export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
+
+export const securityHeaders = {
+  'Content-Security-Policy': "default-src 'none'; base-uri 'none'; form-action 'none'",
+  'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+  'Permissions-Policy': 'geolocation=()',
+};


### PR DESCRIPTION
## Summary
- secure Express server with Helmet and express-rate-limit
- add security headers in Supabase edge functions
- introduce simple in-memory rate limit on edge API
- document headers and rate limits

## Testing
- `pnpm lint` *(fails: Unexpected any, etc.)*
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68828f230c9c832dbfe18324b663e8cd