### PR TITLE
Implement multi-environment support

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,8 @@
+# Development environment configuration
+SUPABASE_URL=https://dev.supabase.local
+SUPABASE_SERVICE_ROLE_KEY=dev-key
+UNES_EMAIL=
+UNES_PASSWORD=
+CAS_USER=
+CAS_PASS=
+JWT_SECRET=dev-secret

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,8 @@
+# Production environment configuration
+SUPABASE_URL=https://prod.supabase.example
+SUPABASE_SERVICE_ROLE_KEY=prod-key
+UNES_EMAIL=
+UNES_PASSWORD=
+CAS_USER=
+CAS_PASS=
+JWT_SECRET=prod-secret

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,8 @@
+# Staging environment configuration
+SUPABASE_URL=https://staging.supabase.example
+SUPABASE_SERVICE_ROLE_KEY=staging-key
+UNES_EMAIL=
+UNES_PASSWORD=
+CAS_USER=
+CAS_PASS=
+JWT_SECRET=staging-secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: corepack enable
+      - name: Select env
+        run: |
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            echo "NODE_ENV=staging" >> "$GITHUB_ENV"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "NODE_ENV=production" >> "$GITHUB_ENV"
+          else
+            echo "NODE_ENV=development" >> "$GITHUB_ENV"
+          fi
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ dist-ssr
 *.sw?
 coverage
 __pycache__/
+.env*
+!.env.example
+!.env.development.example
+!.env.staging.example
+!.env.production.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 # Build stage
+ARG NODE_ENV=production
 FROM node:20 AS builder
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 COPY . .
+COPY .env.$NODE_ENV ./.env
 RUN pnpm build
 
 # Production stage
@@ -12,4 +14,5 @@ WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY package.json ./
 RUN npm install --omit=dev && npm install ts-node
+ENV NODE_ENV=$NODE_ENV
 CMD ["node", "--loader", "ts-node/esm", "src/index.ts"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MED-MNG Backend
-[![CI](https://github.com/med-mng/med-mng/actions/workflows/ci.yml/badge.svg)](https://github.com/med-mng/med-mng/actions/workflows/ci.yml) ![version](https://img.shields.io/badge/version-0.1.0-blue) ![license](https://img.shields.io/badge/license-MIT-green)
+[![CI](https://github.com/med-mng/med-mng/actions/workflows/ci.yml/badge.svg)](https://github.com/med-mng/med-mng/actions/workflows/ci.yml) ![version](https://img.shields.io/badge/version-0.1.0-blue) ![license](https://img.shields.io/badge/license-MIT-green) ![env](https://img.shields.io/badge/env-managed-brightgreen)
 
 
 This repository contains the server side of the MED-MNG platform. It exposes a set of Supabase edge functions and background workers used to manage medical learning content generated from musical AI.
@@ -33,11 +33,16 @@ This repository contains the server side of the MED-MNG platform. It exposes a s
 pnpm install
 ```
 
-2. Copy `.env.example` to `.env` and adjust values
+2. Create environment files from the provided templates
 
 ```bash
-cp .env.example .env
+cp .env.development.example .env.development
+cp .env.staging.example .env.staging
+cp .env.production.example .env.production
 ```
+
+Set `NODE_ENV` to `development`, `staging`, or `production` to load the
+corresponding file.
 
 ## Error Handling
 
@@ -67,6 +72,18 @@ pnpm start:server
 docker build -t med-mng .
 docker run -p 3000:3000 med-mng
 ```
+
+## Multi-environment workflow
+
+The backend automatically loads the `.env.<NODE_ENV>` file. Set `NODE_ENV`
+to `development`, `staging`, or `production` when running scripts or in CI.
+Example:
+
+```bash
+NODE_ENV=staging pnpm build
+```
+
+Each environment uses isolated credentials and should not share secrets.
 
 ## Key Endpoints
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.56.2
         version: 5.82.0(react@18.3.1)
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/react-window':
         specifier: ^1.8.8
         version: 1.8.8
@@ -116,6 +119,12 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       embla-carousel-react:
         specifier: ^8.3.0
         version: 8.6.0(react@18.3.1)
@@ -1837,6 +1846,10 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1880,6 +1893,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2437,6 +2453,13 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5810,6 +5833,10 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.2.6
+
   '@types/estree@1.0.8': {}
 
   '@types/graceful-fs@4.1.9':
@@ -5855,6 +5882,9 @@ snapshots:
       csstype: 3.1.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -6437,6 +6467,12 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.6
       csstype: 3.1.3
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/config/loadEnv.ts
+++ b/src/config/loadEnv.ts
@@ -1,0 +1,11 @@
+import { config } from 'dotenv'
+import { existsSync } from 'fs'
+import path from 'path'
+
+export function loadEnv() {
+  const env = process.env.NODE_ENV || 'development'
+  const envFile = path.resolve(process.cwd(), `.env.${env}`)
+  if (existsSync(envFile)) {
+    config({ path: envFile })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
 import express from 'express';
 import { healthCheck } from './controllers/healthController';
 import { errorHandler } from './middleware/errorHandler';
+import { loadEnv } from './config/loadEnv';
+
+loadEnv();
 
 const app = express();
-const port = import.meta.env.PORT || 3000;
+const port = process.env.PORT || import.meta.env.PORT || 3000;
 
 app.get('/health', healthCheck);
 


### PR DESCRIPTION
## Summary
- add environment examples and ignore real env files
- load env vars at runtime depending on NODE_ENV
- wire Docker build to copy env file for the chosen environment
- update CI workflow to set NODE_ENV automatically
- document multi-env setup in README

## Testing
- `pnpm lint` *(fails: Unexpected any and prettier issues)*
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68828f903dac832d88f74255ee6ba40e