### PR TITLE
Add cancel IA task endpoint

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -71,3 +71,6 @@ verify_jwt = true
 
 [functions.openai-image]
 verify_jwt = true
+[functions.cancel-ia-task]
+verify_jwt = true
+

--- a/supabase/functions/cancel-ia-task/index.ts
+++ b/supabase/functions/cancel-ia-task/index.ts
@@ -1,0 +1,100 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+  }
+
+  try {
+    const { taskId, provider = 'local', reason = 'user_cancel' } = await req.json();
+
+    if (!taskId) {
+      return new Response(
+        JSON.stringify({ error: 'taskId is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+      { auth: { persistSession: false } }
+    );
+
+    let userId: string | null = null;
+    const authHeader = req.headers.get('Authorization');
+    if (authHeader) {
+      const { data } = await supabase.auth.getUser(authHeader.replace('Bearer ', ''));
+      userId = data.user?.id ?? null;
+    }
+
+    let cancelled = false;
+    let message = '';
+
+    try {
+      if (provider === 'suno') {
+        const apiKey = Deno.env.get('SUNO_API_KEY');
+        if (apiKey) {
+          const resp = await fetch(`https://api.suno.ai/tasks/${taskId}`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${apiKey}` },
+          });
+          cancelled = resp.ok;
+          message = await resp.text();
+        }
+      } else if (provider === 'openai') {
+        const apiKey = Deno.env.get('OPENAI_API_KEY');
+        if (apiKey) {
+          const resp = await fetch(`https://api.openai.com/v1/jobs/${taskId}/cancel`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              'Content-Type': 'application/json',
+            },
+          });
+          cancelled = resp.ok;
+          message = await resp.text();
+        }
+      } else {
+        cancelled = true;
+        message = 'Task marked as cancelled';
+      }
+    } catch (err) {
+      message = err.message;
+      cancelled = false;
+    }
+
+    if (cancelled && userId) {
+      await supabase.rpc('med_mng_increment_quota');
+    }
+
+    await supabase.from('ia_task_cancellations').insert({
+      task_id: taskId,
+      user_id: userId,
+      provider,
+      reason,
+      success: cancelled,
+    });
+
+    return new Response(
+      JSON.stringify({ status: cancelled ? 'cancelled' : 'failed', message }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+

--- a/supabase/migrations/20250802100000-cancel-ia-task.sql
+++ b/supabase/migrations/20250802100000-cancel-ia-task.sql
@@ -1,0 +1,31 @@
+-- Add table for IA task cancellations and increment quota function
+
+CREATE TABLE public.ia_task_cancellations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_id TEXT NOT NULL,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  provider TEXT,
+  reason TEXT,
+  success BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.ia_task_cancellations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role manages cancellations" ON public.ia_task_cancellations
+  FOR ALL USING (auth.jwt() ->> 'role' = 'service_role');
+
+-- Function to refund a credit when a task is cancelled
+CREATE OR REPLACE FUNCTION public.med_mng_increment_quota()
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE public.med_mng_subscriptions
+  SET credits_left = credits_left + 1,
+      updated_at = now()
+  WHERE user_id = auth.uid();
+END;
+$$;
+


### PR DESCRIPTION
## Summary
- add `cancel-ia-task` edge function to allow cancelling AI jobs
- log cancellations and refund credits via new SQL migration
- secure new function in `config.toml`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688295325dc8832d98919faa3cc20d13