### PR TITLE
Implement onboarding help endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The main API is served from the `med-mng-api` edge function.
 - `POST /subscriptions/checkout` – create Stripe checkout session
 - `GET /quota` – remaining generation quota
 - `GET /verify-item/:id` – validate a learning item
+- `GET /help/onboarding` – onboarding steps (public, ?lang=xx)
 
 All routes require Supabase authentication and return JSON.
 

--- a/docs/help-endpoint.md
+++ b/docs/help-endpoint.md
@@ -1,0 +1,43 @@
+# Onboarding & Help Endpoint
+
+This endpoint exposes onboarding steps and contextual help so the frontend can dynamically display messages.
+
+## Database
+
+Onboarding content is stored in the `onboarding_steps` table:
+
+- `id` UUID primary key
+- `key` unique identifier for the tip
+- `title` JSONB object with translations
+- `body` JSONB object with translations
+- `type` hint category (`onboarding`, `tooltip`...)
+- `version` integer version number
+- `is_active` boolean flag
+- `created_at` and `updated_at` timestamps
+
+Row level security allows public read access while keeping write access to the service role.
+
+## Endpoint
+
+`GET /help/onboarding?lang=fr`
+
+Returns all active steps sorted by `id`. The `lang` query parameter selects the desired language (defaults to `en`).
+
+Example response:
+```json
+{
+  "steps": [
+    {
+      "id": 1,
+      "key": "welcome",
+      "title": "Bienvenue !",
+      "body": "Découvrez comment générer vos premières chansons…",
+      "type": "onboarding",
+      "version": 1,
+      "is_active": true
+    }
+  ]
+}
+```
+
+If a translation is missing for the requested language, the English text is used as fallback.

--- a/supabase/functions/med-mng-api/index.ts
+++ b/supabase/functions/med-mng-api/index.ts
@@ -8,6 +8,7 @@ import { handleLibrary } from './routes/library.ts';
 import { handleQuota } from './routes/quota.ts';
 import { handleVerify } from './routes/verify.ts';
 import { handleComplete } from './routes/complete.ts';
+import { handleHelp } from './routes/help.ts';
 import { log } from './logger.ts';
 
 const rateMap = new Map<string, { count: number; reset: number }>();
@@ -37,11 +38,15 @@ serve(async (req) => {
     );
   }
 
-  const { error, supabase, user } = await validateAuth(req);
-  if (error) return error;
-
   const url = new URL(req.url);
   const path = url.pathname.replace('/functions/v1/med-mng-api', '');
+
+  // Public help endpoints before auth check
+  const publicRes = await handleHelp(req, null, path, url);
+  if (publicRes) return publicRes;
+
+  const { error, supabase, user } = await validateAuth(req);
+  if (error) return error;
 
   try {
     // Route handlers

--- a/supabase/functions/med-mng-api/routes/help.ts
+++ b/supabase/functions/med-mng-api/routes/help.ts
@@ -1,0 +1,48 @@
+import { corsHeaders, securityHeaders } from '../types.ts';
+
+export async function handleHelp(
+  req: Request,
+  supabase: any | null,
+  path: string,
+  url: URL
+) {
+  // GET /help/onboarding
+  // GET /onboarding-steps
+  if (
+    (path === '/help/onboarding' || path === '/onboarding-steps') &&
+    req.method === 'GET'
+  ) {
+    const lang = url.searchParams.get('lang') || 'en';
+    if (!supabase) {
+      const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2');
+      supabase = createClient(
+        Deno.env.get('SUPABASE_URL') ?? '',
+        Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+      );
+    }
+
+    const { data, error } = await supabase
+      .from('onboarding_steps')
+      .select('id,key,title,body,type,version,is_active')
+      .eq('is_active', true)
+      .order('id');
+
+    if (error) throw error;
+
+    const steps = (data || []).map((row: any) => ({
+      id: row.id,
+      key: row.key,
+      title: row.title?.[lang] ?? row.title?.en ?? '',
+      body: row.body?.[lang] ?? row.body?.en ?? '',
+      type: row.type,
+      version: row.version,
+      is_active: row.is_active,
+    }));
+
+    return new Response(JSON.stringify({ steps }), {
+      headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  return null;
+}

--- a/supabase/migrations/20250812120000-a36e2d82-84ce-4e30-b4db-afcd418e3b53.sql
+++ b/supabase/migrations/20250812120000-a36e2d82-84ce-4e30-b4db-afcd418e3b53.sql
@@ -1,0 +1,26 @@
+-- Table pour stocker l'onboarding et l'aide contextuelle
+CREATE TABLE public.onboarding_steps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key TEXT UNIQUE NOT NULL,
+  title JSONB NOT NULL,
+  body JSONB NOT NULL,
+  type TEXT NOT NULL DEFAULT 'onboarding',
+  version INTEGER NOT NULL DEFAULT 1,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Activer la RLS
+ALTER TABLE public.onboarding_steps ENABLE ROW LEVEL SECURITY;
+
+-- Lecture publique
+CREATE POLICY "Public can read onboarding" ON public.onboarding_steps
+  FOR SELECT USING (true);
+
+-- Gestion complète pour le service role
+CREATE POLICY "Service role manages onboarding" ON public.onboarding_steps
+  FOR ALL USING (auth.jwt() ->> 'role' = 'service_role');
+
+-- Index de filtrage
+CREATE INDEX idx_onboarding_steps_active ON public.onboarding_steps(is_active);

--- a/test/helpRoute.test.ts
+++ b/test/helpRoute.test.ts
@@ -1,0 +1,39 @@
+import { handleHelp } from '../supabase/functions/med-mng-api/routes/help.ts';
+
+const createRequest = (path: string) => new Request(`https://example.com${path}`);
+
+describe('help route', () => {
+  test('GET /help/onboarding returns steps in requested language', async () => {
+    const supabase = {
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            order: jest.fn(() => Promise.resolve({
+              data: [
+                {
+                  id: 1,
+                  key: 'welcome',
+                  title: { en: 'Welcome', fr: 'Bienvenue' },
+                  body: { en: 'body', fr: 'corps' },
+                  type: 'onboarding',
+                  version: 1,
+                  is_active: true,
+                },
+              ],
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    } as any;
+
+    const req = createRequest('/help/onboarding?lang=fr');
+    const res = await handleHelp(req, supabase, '/help/onboarding', new URL(req.url));
+    expect(res).not.toBeNull();
+    if (res) {
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.steps[0].title).toBe('Bienvenue');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add new onboarding_steps table with RLS policies
- provide `/help/onboarding` route in edge functions
- expose public help routes before auth
- document new endpoint and DB schema
- test help route logic

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688296d56a20832db5c173e222a98b08