### PR TITLE
Implement pagination for songs and library API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MED-MNG Backend
-[![CI](https://github.com/med-mng/med-mng/actions/workflows/ci.yml/badge.svg)](https://github.com/med-mng/med-mng/actions/workflows/ci.yml) ![version](https://img.shields.io/badge/version-0.1.0-blue) ![license](https://img.shields.io/badge/license-MIT-green) ![Docker Image Size](https://img.shields.io/docker/image-size/medmng/backend?label=image%20size) ![Security Scan](https://img.shields.io/badge/security-passing-brightgreen)
 
+[![CI](https://github.com/med-mng/med-mng/actions/workflows/ci.yml/badge.svg)](https://github.com/med-mng/med-mng/actions/workflows/ci.yml) ![version](https://img.shields.io/badge/version-0.1.0-blue) ![license](https://img.shields.io/badge/license-MIT-green) ![Docker Image Size](https://img.shields.io/docker/image-size/medmng/backend?label=image%20size) ![Security Scan](https://img.shields.io/badge/security-passing-brightgreen)
 
 This repository contains the server side of the MED-MNG platform. It exposes a set of Supabase edge functions and background workers used to manage medical learning content generated from musical AI.
 
@@ -73,6 +73,7 @@ docker run --rm -p 3000:3000 med-mng
 The multi-stage build installs dependencies, runs tests and copies only the
 compiled output to the final image. You can push the resulting image to any
 registry using `docker push`.
+
 #### Docker Compose
 
 ```bash
@@ -80,16 +81,17 @@ docker compose up --build
 ```
 
 Scripts for database management are available in `scripts/`:
+
 - `init.sh` applies migrations
 - `reset-db.sh` drops and recreates the DB
 - `seed.sh` inserts test data
-
 
 ## Key Endpoints
 
 The main API is served from the `med-mng-api` edge function.
 
 - `POST /songs` – create a new song
+- `GET /songs` – list generated songs (paginated)
 - `GET /songs/:id/stream` – stream a generated track
 - `POST /songs/:id/like` – toggle like
 - `GET /songs/:id/lyrics` – fetch lyrics from Suno
@@ -97,6 +99,23 @@ The main API is served from the `med-mng-api` edge function.
 - `POST /subscriptions/checkout` – create Stripe checkout session
 - `GET /quota` – remaining generation quota
 - `GET /verify-item/:id` – validate a learning item
+
+### Pagination
+
+Endpoints returning lists (`/library` and `/songs`) accept `page` and `limit`
+query parameters. Default is `page=1` and `limit=20` (max 50). Responses
+include these values and `totalCount`:
+
+```json
+{
+  "items": [
+    /* ... */
+  ],
+  "page": 2,
+  "limit": 12,
+  "totalCount": 103
+}
+```
 
 All routes require Supabase authentication and return JSON.
 
@@ -109,6 +128,7 @@ pnpm ts-node scripts/auto-clean-oic.ts
 ```
 
 See [docs/data-cleaning.md](docs/data-cleaning.md) for details.
+
 ## API Security
 
 Security headers such as **Content-Security-Policy**, **Strict-Transport-Security**, **X-Frame-Options** and others are automatically applied to every response. The edge functions merge these headers with CORS settings and the Express server uses Helmet.

--- a/supabase/functions/med-mng-api/routes/library.ts
+++ b/supabase/functions/med-mng-api/routes/library.ts
@@ -1,51 +1,73 @@
-
 import { corsHeaders, securityHeaders, AddToLibraryRequest } from '../types.ts';
 
-export async function handleLibrary(req: Request, supabase: any, path: string, url: URL) {
+export async function handleLibrary(
+  req: Request,
+  supabase: any,
+  path: string,
+  url: URL
+) {
   // POST /library - Add to library
   if (path === '/library' && req.method === 'POST') {
     const { song_id }: AddToLibraryRequest = await req.json();
-    
+
     const { error } = await supabase.rpc('med_mng_add_to_library', { song_id });
-    
+
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify({ success: true }), {
+      headers: {
+        ...corsHeaders,
+        ...securityHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
   }
 
   // DELETE /library/:songId - Remove from library
   if (path.startsWith('/library/') && req.method === 'DELETE') {
     const songId = path.split('/')[2];
-    
-    const { error } = await supabase.rpc('med_mng_remove_from_library', { song_id: songId });
-    
+
+    const { error } = await supabase.rpc('med_mng_remove_from_library', {
+      song_id: songId,
+    });
+
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify({ success: true }), {
+      headers: {
+        ...corsHeaders,
+        ...securityHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
   }
 
   // GET /library - Get user library
   if (path === '/library' && req.method === 'GET') {
-    const page = parseInt(url.searchParams.get('page') || '1');
-    const limit = parseInt(url.searchParams.get('limit') || '20');
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
+    const limit = Math.min(50, parseInt(url.searchParams.get('limit') || '20'));
     const offset = (page - 1) * limit;
 
-    const { data, error } = await supabase
+    const { data, count, error } = await supabase
       .from('med_mng_view_library')
-      .select('*')
+      .select(
+        'id,title,suno_audio_id,meta,created_at,added_to_library_at,is_liked',
+        { count: 'exact' }
+      )
+      .order('added_to_library_at', { ascending: false })
       .range(offset, offset + limit - 1);
 
     if (error) throw error;
 
     return new Response(
-      JSON.stringify(data),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
+      JSON.stringify({ items: data, page, limit, totalCount: count || 0 }),
+      {
+        headers: {
+          ...corsHeaders,
+          ...securityHeaders,
+          'Content-Type': 'application/json',
+        },
+      }
     );
   }
 

--- a/supabase/functions/med-mng-api/routes/songs.ts
+++ b/supabase/functions/med-mng-api/routes/songs.ts
@@ -1,22 +1,54 @@
-
 import { corsHeaders, securityHeaders, CreateSongRequest } from '../types.ts';
 import { log } from '../logger.ts';
 
 declare const Deno: { env: { get(key: string): string | undefined } };
 
 export async function handleSongs(req: Request, supabase: any, path: string) {
+  // GET /songs - List songs with pagination
+  if (path === '/songs' && req.method === 'GET') {
+    const url = new URL(req.url);
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
+    const limit = Math.min(50, parseInt(url.searchParams.get('limit') || '20'));
+    const offset = (page - 1) * limit;
+
+    const { data, count, error } = await supabase
+      .from('med_mng_songs')
+      .select('id,title,suno_audio_id,meta,created_at', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+
+    return new Response(
+      JSON.stringify({ items: data, page, limit, totalCount: count || 0 }),
+      {
+        headers: {
+          ...corsHeaders,
+          ...securityHeaders,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+
   // POST /songs - Create a new song
   if (path === '/songs' && req.method === 'POST') {
     const { title, suno_audio_id, meta }: CreateSongRequest = await req.json();
-    
+
     // Check user quota first
-    const { data: quotaData } = await supabase.rpc('med_mng_get_remaining_quota');
-    
+    const { data: quotaData } = await supabase.rpc(
+      'med_mng_get_remaining_quota'
+    );
+
     if (!quotaData || quotaData <= 0) {
-      return new Response(
-        JSON.stringify({ error: 'Quota insuffisant' }),
-        { status: 403, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-      );
+      return new Response(JSON.stringify({ error: 'Quota insuffisant' }), {
+        status: 403,
+        headers: {
+          ...corsHeaders,
+          ...securityHeaders,
+          'Content-Type': 'application/json',
+        },
+      });
     }
 
     // Insert song (trigger will decrement quota)
@@ -28,16 +60,23 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
 
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify(data),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify(data), {
+      headers: {
+        ...corsHeaders,
+        ...securityHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
   }
 
   // GET /songs/:id/stream - Proxy streaming
-  if (path.startsWith('/songs/') && path.endsWith('/stream') && req.method === 'GET') {
+  if (
+    path.startsWith('/songs/') &&
+    path.endsWith('/stream') &&
+    req.method === 'GET'
+  ) {
     const songId = path.split('/')[2];
-    
+
     const { data: song, error } = await supabase
       .from('med_mng_songs')
       .select('suno_audio_id')
@@ -45,18 +84,22 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
       .single();
 
     if (error || !song) {
-      return new Response(
-        JSON.stringify({ error: 'Song not found' }),
-        { status: 404, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-      );
+      return new Response(JSON.stringify({ error: 'Song not found' }), {
+        status: 404,
+        headers: {
+          ...corsHeaders,
+          ...securityHeaders,
+          'Content-Type': 'application/json',
+        },
+      });
     }
 
     // Proxy to Suno with streaming support
     const sunoUrl = `https://apibox.erweima.ai/api/v1/audio/${song.suno_audio_id}`;
     const sunoResponse = await fetch(sunoUrl, {
       headers: {
-        'Authorization': `Bearer ${Deno.env.get('SUNO_API_KEY')}`,
-        'Range': req.headers.get('Range') || '',
+        Authorization: `Bearer ${Deno.env.get('SUNO_API_KEY')}`,
+        Range: req.headers.get('Range') || '',
       },
     });
 
@@ -70,7 +113,8 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
 
     // Copy range headers for streaming
     if (sunoResponse.headers.get('Content-Range')) {
-      responseHeaders['Content-Range'] = sunoResponse.headers.get('Content-Range')!;
+      responseHeaders['Content-Range'] =
+        sunoResponse.headers.get('Content-Range')!;
       responseHeaders['Accept-Ranges'] = 'bytes';
     }
 
@@ -83,21 +127,26 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
   // POST /songs/:id/like - Toggle like
   if (path.match(/^\/songs\/[^/]+\/like$/) && req.method === 'POST') {
     const songId = path.split('/')[2];
-    
-    const { data: isLiked, error } = await supabase.rpc('med_mng_toggle_like', { song_id: songId });
-    
+
+    const { data: isLiked, error } = await supabase.rpc('med_mng_toggle_like', {
+      song_id: songId,
+    });
+
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({ liked: isLiked }),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify({ liked: isLiked }), {
+      headers: {
+        ...corsHeaders,
+        ...securityHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
   }
 
   // GET /songs/:id/lyrics - Get lyrics
   if (path.match(/^\/songs\/[^/]+\/lyrics$/) && req.method === 'GET') {
     const songId = path.split('/')[2];
-    
+
     const { data: song, error } = await supabase
       .from('med_mng_songs')
       .select('lyrics, suno_audio_id')
@@ -105,48 +154,68 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
       .single();
 
     if (error || !song) {
-      return new Response(
-        JSON.stringify({ error: 'Song not found' }),
-        { status: 404, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-      );
+      return new Response(JSON.stringify({ error: 'Song not found' }), {
+        status: 404,
+        headers: {
+          ...corsHeaders,
+          ...securityHeaders,
+          'Content-Type': 'application/json',
+        },
+      });
     }
 
     // If lyrics not cached, fetch from Suno
     if (!song.lyrics || Object.keys(song.lyrics).length === 0) {
       try {
-        const lyricsResponse = await fetch(`https://apibox.erweima.ai/api/v1/get-timestamped-lyrics/${song.suno_audio_id}`, {
-          headers: {
-            'Authorization': `Bearer ${Deno.env.get('SUNO_API_KEY')}`,
-          },
-        });
-        
+        const lyricsResponse = await fetch(
+          `https://apibox.erweima.ai/api/v1/get-timestamped-lyrics/${song.suno_audio_id}`,
+          {
+            headers: {
+              Authorization: `Bearer ${Deno.env.get('SUNO_API_KEY')}`,
+            },
+          }
+        );
+
         if (lyricsResponse.ok) {
           const lyricsData = await lyricsResponse.json();
-          
+
           // Update song with lyrics
           await supabase
             .from('med_mng_songs')
             .update({ lyrics: lyricsData })
             .eq('id', songId);
-          
-          return new Response(
-            JSON.stringify(lyricsData),
-            { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-          );
+
+          return new Response(JSON.stringify(lyricsData), {
+            headers: {
+              ...corsHeaders,
+              ...securityHeaders,
+              'Content-Type': 'application/json',
+            },
+          });
         }
       } catch (error) {
         log('error', 'Error fetching lyrics', error);
         return new Response(
           JSON.stringify({ error: 'Erreur récupération paroles' }),
-          { status: 500, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
+          {
+            status: 500,
+            headers: {
+              ...corsHeaders,
+              ...securityHeaders,
+              'Content-Type': 'application/json',
+            },
+          }
         );
       }
     }
 
-    return new Response(
-      JSON.stringify(song.lyrics || {}),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify(song.lyrics || {}), {
+      headers: {
+        ...corsHeaders,
+        ...securityHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
   }
 
   return null;

--- a/supabase/migrations/20250802090000-pagination-index.sql
+++ b/supabase/migrations/20250802090000-pagination-index.sql
@@ -1,0 +1,3 @@
+-- Add indexes for pagination performance
+CREATE INDEX IF NOT EXISTS idx_med_mng_songs_created_at ON public.med_mng_songs(created_at);
+CREATE INDEX IF NOT EXISTS idx_med_mng_user_songs_created_at ON public.med_mng_user_songs(created_at);

--- a/test/api.integration.test.ts
+++ b/test/api.integration.test.ts
@@ -1,4 +1,5 @@
 import { handleSongs } from '../supabase/functions/med-mng-api/routes/songs.ts';
+import { handleLibrary } from '../supabase/functions/med-mng-api/routes/library.ts';
 import { handleQuota } from '../supabase/functions/med-mng-api/routes/quota.ts';
 
 const createRequest = (path: string, method: string, body?: any) =>
@@ -57,5 +58,40 @@ describe('med-mng-api route handlers', () => {
     expect(res?.status).toBe(200);
     const body = await res?.json();
     expect(body.remaining_credits).toBe(5);
+  });
+
+  test('GET /library returns paginated list', async () => {
+    const range = jest
+      .fn()
+      .mockResolvedValue({ data: [{ id: '1' }], count: 10, error: null });
+    const supabase = {
+      from: jest.fn(() => ({ select: () => ({ order: () => ({ range }) }) })),
+    } as any;
+    const req = createRequest('/library?page=1&limit=1', 'GET');
+    const res = await handleLibrary(
+      req,
+      supabase,
+      '/library',
+      new URL(req.url)
+    );
+    expect(res?.status).toBe(200);
+    const body = await res?.json();
+    expect(body.items.length).toBe(1);
+    expect(body.totalCount).toBe(10);
+  });
+
+  test('GET /songs returns paginated list', async () => {
+    const range = jest
+      .fn()
+      .mockResolvedValue({ data: [{ id: '1' }], count: 5, error: null });
+    const supabase = {
+      from: jest.fn(() => ({ select: () => ({ order: () => ({ range }) }) })),
+    } as any;
+    const req = createRequest('/songs?page=2&limit=1', 'GET');
+    const res = await handleSongs(req, supabase, '/songs');
+    expect(res?.status).toBe(200);
+    const body = await res?.json();
+    expect(body.page).toBe(2);
+    expect(body.totalCount).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary
- paginate `/library` endpoint and return metadata
- add `/songs` GET endpoint with pagination
- document new pagination support
- create indexes to speed up listing queries
- test library and songs pagination

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882966b6234832da09f1534939cd400