### PR TITLE
Implement standardized API error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ corresponding file.
 ## Error Handling
 
 All backend endpoints must return explicit errors with the correct HTTP status code. See [docs/errors.md](docs/errors.md) for the full policy.
+Responses use `{ "error": "CODE", "code": <status>, "message": "details" }`.
 
 3. Start Supabase locally
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -5,7 +5,8 @@ This project aims to avoid silent failures across the stack. Any error occurring
 ## Backend
 - Use the `log` utility to log errors with a timestamp and severity.
 - API routes should return appropriate HTTP status codes (400 for bad requests, 401 for unauthenticated, 403 for forbidden, 404 for missing resources, 429 for quota issues, 500 for server errors).
-- Avoid empty `catch` blocks. When an unexpected error occurs, log it and return a JSON payload such as `{ "error": "Message" }`.
+- Avoid empty `catch` blocks. When an unexpected error occurs, log it and return a JSON payload such as `{ "error": "ERROR_CODE", "code": 500, "message": "Human readable" }`.
+- Standard error structure: `{ "error": "CODE", "code": <http status>, "message": "Human message" }`.
 
 ## Frontend
 - Display API error messages to users via toast or alert components.

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -16,5 +16,5 @@ export function errorHandler(
     message: err instanceof Error ? err.message : 'Unknown error',
     details: err,
   });
-  res.status(500).json({ error: 'Internal Server Error' });
+  res.status(500).json({ error: 'SERVER_ERROR', code: 500, message: 'Internal Server Error' });
 }

--- a/supabase/functions/med-mng-api/auth.ts
+++ b/supabase/functions/med-mng-api/auth.ts
@@ -1,6 +1,7 @@
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { corsHeaders } from './types.ts';
+import { errorResponse } from './response.ts';
 
 export async function validateAuth(req: Request) {
   const supabase = createClient(
@@ -11,10 +12,7 @@ export async function validateAuth(req: Request) {
   const authHeader = req.headers.get('Authorization');
   if (!authHeader) {
     return {
-      error: new Response(
-        JSON.stringify({ error: 'Authorization header required' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      ),
+      error: errorResponse(401, 'AUTH_REQUIRED', 'Authorization header required'),
       supabase: null,
       user: null
     };
@@ -26,10 +24,7 @@ export async function validateAuth(req: Request) {
 
   if (authError || !user) {
     return {
-      error: new Response(
-        JSON.stringify({ error: 'Invalid authentication' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      ),
+      error: errorResponse(401, 'INVALID_AUTH', 'Invalid authentication'),
       supabase: null,
       user: null
     };

--- a/supabase/functions/med-mng-api/index.ts
+++ b/supabase/functions/med-mng-api/index.ts
@@ -10,6 +10,7 @@ import { handleVerify } from './routes/verify.ts';
 import { handleComplete } from './routes/complete.ts';
 import { handleHelp } from './routes/help.ts';
 import { log } from './logger.ts';
+import { errorResponse } from './response.ts';
 
 const rateMap = new Map<string, { count: number; reset: number }>();
 
@@ -32,10 +33,7 @@ serve(async (req) => {
 
   const ip = req.headers.get('x-forwarded-for') ?? 'anon';
   if (!checkRate(ip, 60, 60_000)) {
-    return new Response(
-      JSON.stringify({ error: 'Too Many Requests' }),
-      { status: 429, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return errorResponse(429, 'RATE_LIMIT', 'Too Many Requests');
   }
 
   const url = new URL(req.url);
@@ -70,16 +68,10 @@ serve(async (req) => {
     response = await handleComplete(req, supabase, path);
     if (response) return response;
 
-    return new Response(
-      JSON.stringify({ error: 'Route not found' }),
-      { status: 404, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return errorResponse(404, 'NOT_FOUND', 'Route not found');
 
   } catch (error) {
     log('error', 'API Error', error);
-    return new Response(
-      JSON.stringify({ error: error.message }),
-      { status: 500, headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return errorResponse(500, 'SERVER_ERROR', (error as Error).message);
   }
 });

--- a/supabase/functions/med-mng-api/response.ts
+++ b/supabase/functions/med-mng-api/response.ts
@@ -1,0 +1,15 @@
+import { corsHeaders, securityHeaders } from "./types.ts";
+export function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+      ...securityHeaders,
+    },
+  });
+}
+
+export function errorResponse(status: number, error: string, message: string) {
+  return jsonResponse({ error, code: status, message }, status);
+}

--- a/supabase/functions/med-mng-api/routes/library.ts
+++ b/supabase/functions/med-mng-api/routes/library.ts
@@ -1,3 +1,4 @@
+import { jsonResponse, errorResponse } from "../response.ts";
 import { corsHeaders, securityHeaders, AddToLibraryRequest } from '../types.ts';
 
 export async function handleLibrary(
@@ -14,13 +15,7 @@ export async function handleLibrary(
 
     if (error) throw error;
 
-    return new Response(JSON.stringify({ success: true }), {
-      headers: {
-        ...corsHeaders,
-        ...securityHeaders,
-        'Content-Type': 'application/json',
-      },
-    });
+    return jsonResponse({ success: true });
   }
 
   // DELETE /library/:songId - Remove from library
@@ -33,13 +28,7 @@ export async function handleLibrary(
 
     if (error) throw error;
 
-    return new Response(JSON.stringify({ success: true }), {
-      headers: {
-        ...corsHeaders,
-        ...securityHeaders,
-        'Content-Type': 'application/json',
-      },
-    });
+    return jsonResponse({ success: true });
   }
 
   // GET /library - Get user library
@@ -59,16 +48,7 @@ export async function handleLibrary(
 
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({ items: data, page, limit, totalCount: count || 0 }),
-      {
-        headers: {
-          ...corsHeaders,
-          ...securityHeaders,
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    return jsonResponse({ items: data, page, limit, totalCount: count || 0 });
   }
 
   return null;

--- a/supabase/functions/med-mng-api/routes/quota.ts
+++ b/supabase/functions/med-mng-api/routes/quota.ts
@@ -1,5 +1,5 @@
+import { jsonResponse } from "../response.ts";
 
-import { corsHeaders, securityHeaders } from '../types.ts';
 
 export async function handleQuota(req: Request, supabase: any, path: string) {
   // GET /quota - Get remaining quota
@@ -8,10 +8,7 @@ export async function handleQuota(req: Request, supabase: any, path: string) {
     
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({ remaining_credits: quota || 0 }),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return jsonResponse({ remaining_credits: quota || 0 });
   }
 
   return null;

--- a/supabase/functions/med-mng-api/routes/songs.ts
+++ b/supabase/functions/med-mng-api/routes/songs.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "../response.ts";
 import { corsHeaders, securityHeaders, CreateSongRequest } from '../types.ts';
 import { log } from '../logger.ts';
 
@@ -41,14 +42,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
     );
 
     if (!quotaData || quotaData <= 0) {
-      return new Response(JSON.stringify({ error: 'Quota insuffisant' }), {
-        status: 403,
-        headers: {
-          ...corsHeaders,
-          ...securityHeaders,
-          'Content-Type': 'application/json',
-        },
-      });
+      return errorResponse(403, 'QUOTA_EXCEEDED', 'Quota insuffisant');
     }
 
     // Insert song (trigger will decrement quota)
@@ -84,14 +78,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
       .single();
 
     if (error || !song) {
-      return new Response(JSON.stringify({ error: 'Song not found' }), {
-        status: 404,
-        headers: {
-          ...corsHeaders,
-          ...securityHeaders,
-          'Content-Type': 'application/json',
-        },
-      });
+      return errorResponse(404, 'SONG_NOT_FOUND', 'Song not found');
     }
 
     // Proxy to Suno with streaming support
@@ -154,14 +141,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
       .single();
 
     if (error || !song) {
-      return new Response(JSON.stringify({ error: 'Song not found' }), {
-        status: 404,
-        headers: {
-          ...corsHeaders,
-          ...securityHeaders,
-          'Content-Type': 'application/json',
-        },
-      });
+      return errorResponse(404, 'SONG_NOT_FOUND', 'Song not found');
     }
 
     // If lyrics not cached, fetch from Suno
@@ -195,17 +175,7 @@ export async function handleSongs(req: Request, supabase: any, path: string) {
         }
       } catch (error) {
         log('error', 'Error fetching lyrics', error);
-        return new Response(
-          JSON.stringify({ error: 'Erreur récupération paroles' }),
-          {
-            status: 500,
-            headers: {
-              ...corsHeaders,
-              ...securityHeaders,
-              'Content-Type': 'application/json',
-            },
-          }
-        );
+        return errorResponse(500, 'LYRICS_FETCH_ERROR', 'Erreur récupération paroles');
       }
     }
 

--- a/supabase/functions/med-mng-api/routes/subscriptions.ts
+++ b/supabase/functions/med-mng-api/routes/subscriptions.ts
@@ -1,10 +1,15 @@
+import { jsonResponse, errorResponse } from "../response.ts";
 
-import { corsHeaders, securityHeaders, CreateSubscriptionRequest } from '../types.ts';
+import { CreateSubscriptionRequest } from '../types.ts';
 
 export async function handleSubscriptions(req: Request, supabase: any) {
   if (req.method === 'POST') {
     const { plan_id, gateway, subscription_id }: CreateSubscriptionRequest = await req.json();
-    
+
+    if (!plan_id || !gateway) {
+      return errorResponse(400, 'INVALID_REQUEST', 'plan_id and gateway required');
+    }
+
     const { error } = await supabase.rpc('med_mng_create_user_sub', {
       plan_name: plan_id,
       gateway_name: gateway,
@@ -13,10 +18,7 @@ export async function handleSubscriptions(req: Request, supabase: any) {
 
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } }
-    );
+    return jsonResponse({ success: true });
   }
 
   return null;

--- a/test/api.integration.test.ts
+++ b/test/api.integration.test.ts
@@ -27,6 +27,8 @@ describe('med-mng-api route handlers', () => {
     });
     const res = await handleSongs(req, supabase, '/songs');
     expect(res?.status).toBe(403);
+    const body = await res?.json();
+    expect(body).toEqual({ error: 'QUOTA_EXCEEDED', code: 403, message: 'Quota insuffisant' });
   });
 
   test('POST /songs creates song when quota ok', async () => {


### PR DESCRIPTION
## Summary
- document new error response structure
- note error response shape in README
- update Express error handler to use standardized format
- add helper utilities for JSON and error responses
- use new helper in song, subscription, library, and quota routes
- enforce quota check with standardized message
- validate subscription request params
- update integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68829d338bd4832db38a4eff6c412416