### PR TITLE
Add Supabase logging service and dashboard docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ SUPABASE_SERVICE_ROLE_KEY=your-key
 # Alerting
 RESEND_API_KEY=
 ALERT_EMAIL=
+DISCORD_WEBHOOK_URL=
+SLACK_WEBHOOK_URL=
 
 # Auth credentials for CAS or other systems
 # UNES credentials for scraping

--- a/README-DEVOPS.md
+++ b/README-DEVOPS.md
@@ -71,6 +71,7 @@ Store them in `.env` for local use and configure the same variables as project s
 - Supabase provides logs for edge functions, database and storage (dashboard ➜ Logs).
 - The Express API logs to stdout via `supabase/functions/med-mng-api/logger.ts`.
 - Alerts can be sent to Discord or Slack when `DISCORD_WEBHOOK_URL` or `SLACK_WEBHOOK_URL` are defined. See `src/services/alertService.ts`.
+- Database logs are stored in the `operation_logs` table via `logService.ts` and can feed a Metabase or Grafana dashboard (see `docs/dashboard-monitoring.md`).
 
 ## 6. Extraction batch / cleaning data
 

--- a/docs/dashboard-monitoring.md
+++ b/docs/dashboard-monitoring.md
@@ -1,0 +1,25 @@
+# Dashboard Monitoring
+
+Example SQL queries to feed a Metabase or Grafana dashboard.
+
+## Total extractions per day
+
+```sql
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) AS extractions
+FROM operation_logs
+WHERE type = 'extraction'
+GROUP BY 1
+ORDER BY 1 DESC;
+```
+
+## Recent backend errors
+
+```sql
+SELECT created_at, message, meta
+FROM operation_logs
+WHERE type = 'error'
+ORDER BY created_at DESC
+LIMIT 50;
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -10,8 +10,14 @@ SENTRY_DSN=your-dsn
 
 The Express server initialises Sentry in `src/index.ts` and reports uncaught errors via `errorHandler.ts`. Context such as environment and release version is automatically attached.
 
+Operations are also stored in the `operation_logs` table through `logService.ts` when `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are configured. This enables building dashboards in Metabase or Grafana directly from the database.
+
 ## Supabase Edge Functions
 
 Edge functions currently log to the console. They can be extended to push errors to Sentry using the HTTP API if needed.
 
 Logs are visible in real time from the Sentry dashboard where you can filter by environment or release.
+
+## Alerts
+
+Critical incidents trigger notifications through Discord or Slack when the `DISCORD_WEBHOOK_URL` or `SLACK_WEBHOOK_URL` variables are set. The helper in `src/services/alertService.ts` posts a simple JSON payload to the configured webhook URL.

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,0 +1,31 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL as string;
+const SUPABASE_SERVICE_ROLE_KEY = process.env
+  .SUPABASE_SERVICE_ROLE_KEY as string;
+
+const client =
+  SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY
+    ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    : null;
+
+export async function logOperation(
+  type: string,
+  message: string,
+  meta?: Record<string, unknown>
+): Promise<void> {
+  if (!client) {
+    console.warn('Supabase not configured for logging');
+    return;
+  }
+
+  const { error } = await client.from('operation_logs').insert({
+    type,
+    message,
+    meta,
+  });
+
+  if (error) {
+    console.error('Failed to insert log', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add `logService.ts` for recording operations in Supabase
- document dashboard SQL queries
- extend logging docs with new service and alerting notes
- document monitoring updates in devops guide
- update env example with webhook URLs

## Testing
- `npm test`
- `npm run lint` *(fails: prettier/prettier errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68829f7512a4832db78346acd819fdc7