### PR TITLE
Add EDN and OIC API routes

### DIFF
--- a/supabase/functions/med-mng-api/index.ts
+++ b/supabase/functions/med-mng-api/index.ts
@@ -9,6 +9,8 @@ import { handleQuota } from './routes/quota.ts';
 import { handleVerify } from './routes/verify.ts';
 import { handleComplete } from './routes/complete.ts';
 import { handleHelp } from './routes/help.ts';
+import { handleEdn } from './routes/edn.ts';
+import { handleOic } from './routes/oic.ts';
 import { log } from './logger.ts';
 
 const rateMap = new Map<string, { count: number; reset: number }>();
@@ -59,6 +61,12 @@ serve(async (req) => {
     if (response) return response;
 
     response = await handleLibrary(req, supabase, path, url);
+    if (response) return response;
+
+    response = await handleEdn(req, supabase, path, url);
+    if (response) return response;
+
+    response = await handleOic(req, supabase, path, url);
     if (response) return response;
 
     response = await handleQuota(req, supabase, path);

--- a/supabase/functions/med-mng-api/routes/edn.ts
+++ b/supabase/functions/med-mng-api/routes/edn.ts
@@ -1,0 +1,57 @@
+import { corsHeaders, securityHeaders } from '../types.ts';
+
+export async function handleEdn(
+  req: Request,
+  supabase: any,
+  path: string,
+  url: URL,
+) {
+  if (path === '/edn' && req.method === 'GET') {
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
+    const limit = Math.min(100, parseInt(url.searchParams.get('limit') || '50'));
+    const offset = (page - 1) * limit;
+
+    const { data, count, error } = await supabase
+      .from('edn_items_immersive')
+      .select('item_code,title,subtitle,slug', { count: 'exact' })
+      .order('item_code')
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      console.error('EDN list error:', error);
+      return new Response(JSON.stringify({ error: 'edn_list_error' }), {
+        status: 500,
+        headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ items: data || [], page, limit, totalCount: count || 0 }),
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
+  if (path.startsWith('/edn/') && req.method === 'GET') {
+    const slug = path.split('/')[2];
+
+    const { data, error } = await supabase
+      .from('edn_items_immersive')
+      .select('*')
+      .eq('slug', slug)
+      .single();
+
+    if (error || !data) {
+      return new Response(JSON.stringify({ error: 'edn_not_found' }), {
+        status: 404,
+        headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  return null;
+}
+

--- a/supabase/functions/med-mng-api/routes/oic.ts
+++ b/supabase/functions/med-mng-api/routes/oic.ts
@@ -1,0 +1,57 @@
+import { corsHeaders, securityHeaders } from '../types.ts';
+
+export async function handleOic(
+  req: Request,
+  supabase: any,
+  path: string,
+  url: URL,
+) {
+  if (path === '/oic' && req.method === 'GET') {
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
+    const limit = Math.min(100, parseInt(url.searchParams.get('limit') || '50'));
+    const offset = (page - 1) * limit;
+
+    const { data, count, error } = await supabase
+      .from('oic_competences')
+      .select('objectif_id,intitule,item_parent,rang,rubrique', { count: 'exact' })
+      .order('objectif_id')
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      console.error('OIC list error:', error);
+      return new Response(JSON.stringify({ error: 'oic_list_error' }), {
+        status: 500,
+        headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ items: data || [], page, limit, totalCount: count || 0 }),
+      { headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
+  if (path.startsWith('/oic/') && req.method === 'GET') {
+    const objectifId = path.split('/')[2];
+
+    const { data, error } = await supabase
+      .from('oic_competences')
+      .select('*')
+      .eq('objectif_id', objectifId)
+      .single();
+
+    if (error || !data) {
+      return new Response(JSON.stringify({ error: 'oic_not_found' }), {
+        status: 404,
+        headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- expose `/edn` and `/oic` endpoints in the Supabase edge function
- return paginated lists and single item lookup

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68829f3bcd84832da61fc5a2891d8e9e