### PR TITLE
Fix asynchronous check in scrape_oic

### DIFF
--- a/src/scripts/scrape_oic.ts
+++ b/src/scripts/scrape_oic.ts
@@ -75,9 +75,10 @@ const RUBRIQUES_MAP: Record<string, string> = {
  */
 async function testPublicAPI(): Promise<boolean> {
   try {
+    const response = await fetch(
+      `${API_BASE}?action=query&meta=siteinfo&format=json&origin=*`
+    );
     console.log('🔍 Test d\'accès public à l\'API MediaWiki...');
-    
-    const response = await fetch(`${API_BASE}?action=query&meta=siteinfo&format=json&origin=*`);
     
     if (response.ok) {
       const data = await response.json();


### PR DESCRIPTION
## Summary
- await fetch response before logging in `testPublicAPI`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a956de78832da87274b559f49cf3