### PR TITLE
Fix TypeScript TS6305 error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,10 +23,7 @@
     "strictNullChecks": false,
     "esModuleInterop": true,
     "allowImportingTsExtensions": true
+    ,"noEmit": true
   },
-  "include": [
-    "src",
-    "supabase",
-    "test/global.d.ts"
-  ]
+
 }


### PR DESCRIPTION
## Summary
- disable emitting from the root `tsconfig.json`
- remove project includes so the references drive source selection

## Testing
- `npm run build`
- `npm run dev` *(server started)*
- `npm test` *(fails: Jest unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68847cf03648832d8491823c203b9079