### PR TITLE
feat: store quiz session metadata

### DIFF
--- a/src/components/quiz/EnhancedQuiz.tsx
+++ b/src/components/quiz/EnhancedQuiz.tsx
@@ -141,19 +141,26 @@ export const EnhancedQuiz: React.FC<EnhancedQuizProps> = ({
 
   const saveQuizSession = async (session: QuizSession) => {
     try {
-      // TODO: Créer la table quiz_sessions via migration
-      console.log('Quiz session completed:', session);
-      // await supabase.from('quiz_sessions').insert({
-      //   user_id: (await supabase.auth.getUser()).data.user?.id,
-      //   item_code: session.itemCode,
-      //   rang: session.rang,
-      //   score: session.score,
-      //   questions_count: session.questions.length,
-      //   correct_answers: session.answers.filter(a => a.isCorrect).length,
-      //   session_data: session
-      // });
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+
+      const { error } = await supabase.from('quiz_sessions').insert({
+        user_id: user?.id,
+        item_code: session.itemCode,
+        rang: session.rang,
+        score: session.score,
+        questions_count: session.questions.length,
+        correct_answers: session.answers.filter(a => a.isCorrect).length,
+        session_data: session
+      });
+
+      if (error) {
+        throw error;
+      }
     } catch (error) {
       console.error('Error saving quiz session:', error);
+      toast.error("Échec de l'enregistrement de la session de quiz");
     }
   };
 

--- a/supabase/migrations/20250822080000_add_quiz_sessions_table.sql
+++ b/supabase/migrations/20250822080000_add_quiz_sessions_table.sql
@@ -1,0 +1,30 @@
+-- Table to store quiz sessions metadata
+CREATE TABLE IF NOT EXISTS public.quiz_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  item_code TEXT NOT NULL,
+  rang TEXT,
+  score INTEGER,
+  questions_count INTEGER,
+  correct_answers INTEGER,
+  session_data JSONB,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Index for user queries
+CREATE INDEX IF NOT EXISTS idx_quiz_sessions_user_id ON public.quiz_sessions(user_id);
+
+-- Enable Row Level Security
+ALTER TABLE public.quiz_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Policies to allow users to manage their own sessions
+CREATE POLICY "Users can insert own quiz sessions"
+  ON public.quiz_sessions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can view own quiz sessions"
+  ON public.quiz_sessions
+  FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create `quiz_sessions` table with RLS policies
- persist quiz session metadata after completion
- notify user if saving fails

## Testing
- `npm test` *(fails: SyntaxError in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f6ac5f4832db2efd97a4011f044