### PR TITLE
feat: add Suno util endpoints with fallback

### DIFF
--- a/src/lib/secureApiClient.ts
+++ b/src/lib/secureApiClient.ts
@@ -94,6 +94,42 @@ export class SecureSunoClient {
 
     return data;
   }
+
+  async convertToWav(audioId: string) {
+    const { data, error } = await supabase.functions.invoke('suno-music-optimized', {
+      body: { action: 'convert-wav', audioId }
+    });
+
+    if (error) {
+      throw new Error(`Suno WAV API Error: ${error.message}`);
+    }
+
+    return data;
+  }
+
+  async removeVocals(audioId: string) {
+    const { data, error } = await supabase.functions.invoke('suno-music-optimized', {
+      body: { action: 'remove-vocals', audioId }
+    });
+
+    if (error) {
+      throw new Error(`Suno Vocal Removal API Error: ${error.message}`);
+    }
+
+    return data;
+  }
+
+  async generateVideo(audioId: string) {
+    const { data, error } = await supabase.functions.invoke('suno-music-optimized', {
+      body: { action: 'generate-video', audioId }
+    });
+
+    if (error) {
+      throw new Error(`Suno Video API Error: ${error.message}`);
+    }
+
+    return data;
+  }
 }
 
 // Export singleton instances

--- a/src/suno/index.ts
+++ b/src/suno/index.ts
@@ -15,7 +15,8 @@ export { getMusicStatus, type MusicStatus, type MusicStatusStage } from '../musi
 export { getTimestampedLyrics, type TimestampedLyrics } from '../music/lyrics';
 export { extendMusic, type ExtendMusicPayload } from '../music/extend';
 
-// Utilitaires (placeholder)
+// Utilitaires
 export { convertToWav } from '../utils/wav';
 export { removeVocals } from '../utils/vocal-remove';
 export { generateVideo } from '../utils/video';
+

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -2,6 +2,13 @@
 import { secureSunoClient as SunoApiClient } from "../lib/secureApiClient";
 
 export async function generateVideo(audioId: string) {
-  // TODO: implémenter dès que l'endpoint sera dispo
-  throw new Error("Not implemented yet – pending Suno video MP4 endpoint");
+  try {
+    return await SunoApiClient.generateVideo(audioId);
+  } catch (error) {
+    console.warn("Suno video generation unavailable", error);
+    return {
+      success: false,
+      message: "Génération vidéo indisponible pour le moment.",
+    };
+  }
 }

--- a/src/utils/vocal-remove.ts
+++ b/src/utils/vocal-remove.ts
@@ -2,6 +2,13 @@
 import { secureSunoClient as SunoApiClient } from "../lib/secureApiClient";
 
 export async function removeVocals(audioId: string) {
-  // TODO: implémenter dès que l'endpoint sera dispo
-  throw new Error("Not implemented yet – pending Suno vocal removal endpoint");
+  try {
+    return await SunoApiClient.removeVocals(audioId);
+  } catch (error) {
+    console.warn("Suno vocal removal unavailable", error);
+    return {
+      success: false,
+      message: "Suppression de voix indisponible pour le moment.",
+    };
+  }
 }

--- a/src/utils/wav.ts
+++ b/src/utils/wav.ts
@@ -2,6 +2,13 @@
 import { secureSunoClient as SunoApiClient } from "../lib/secureApiClient";
 
 export async function convertToWav(audioId: string) {
-  // TODO: implémenter dès que l'endpoint sera dispo
-  throw new Error("Not implemented yet – pending Suno WAV endpoint");
+  try {
+    return await SunoApiClient.convertToWav(audioId);
+  } catch (error) {
+    console.warn("Suno WAV conversion unavailable", error);
+    return {
+      success: false,
+      message: "Conversion WAV indisponible pour le moment.",
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- add Suno client methods for wav conversion, vocal removal and video generation
- surface friendly fallbacks when Suno utilities aren't available

## Testing
- `npm test` (fails: Test Suites: 34 failed, 34 total)
- `npm run lint` (fails: No files matching the pattern "src/index.ts" were found)


------
https://chatgpt.com/codex/tasks/task_e_68a86f77a9cc832da4ba50eacbae7dfa