### PR TITLE
feat: use secure streaming url

### DIFF
--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useToast } from '@/hooks/use-toast';
+import { getSecureStreamUrl, StreamUrlNotFoundError } from '@/services/streamService';
 
 interface Track {
   id: string;
@@ -120,12 +121,21 @@ export const usePlayer = () => {
 
       // Nouvelle piste - obtenir l'URL de streaming sécurisé
       if (!track.stream_url) {
-        // TODO: Appeler l'API pour obtenir l'URL de streaming
-        // const streamUrl = await getSecureStreamUrl(track.id);
-        // track.stream_url = streamUrl;
-        
-        // Pour l'instant, URL fictive
-        track.stream_url = `https://api.placeholder.com/stream/${track.id}`;
+        try {
+          const streamUrl = await getSecureStreamUrl(track.id);
+          track.stream_url = streamUrl;
+        } catch (err) {
+          if (err instanceof StreamUrlNotFoundError) {
+            setState(prev => ({ ...prev, isLoading: false, isPlaying: false }));
+            toast({
+              title: "URL introuvable",
+              description: "Impossible de récupérer l'URL sécurisée",
+              variant: "destructive"
+            });
+            return;
+          }
+          throw err;
+        }
       }
 
       audioRef.current.src = track.stream_url;

--- a/src/services/streamService.ts
+++ b/src/services/streamService.ts
@@ -1,0 +1,18 @@
+export class StreamUrlNotFoundError extends Error {
+  constructor() {
+    super('Stream URL not found');
+    this.name = 'StreamUrlNotFoundError';
+  }
+}
+
+export const getSecureStreamUrl = async (trackId: string): Promise<string> => {
+  const response = await fetch(`/api/stream/${trackId}`);
+  if (!response.ok) {
+    throw new StreamUrlNotFoundError();
+  }
+  const data = await response.json();
+  if (!data?.url) {
+    throw new StreamUrlNotFoundError();
+  }
+  return data.url;
+};


### PR DESCRIPTION
## Summary
- add service to fetch secure streaming URL
- integrate streaming service in player with explicit error handling

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f85c6e0832da8a7ed2ee61d4234