### PR TITLE
feat: secure alerts and cors

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,4 +1,17 @@
-export const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+const allowedOrigins = (Deno.env.get('ALLOWED_ORIGINS') ?? '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+export function getCorsHeaders(origin?: string | null) {
+  const allowedOrigin =
+    origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0] || '';
+
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Headers':
+      'authorization, x-client-info, apikey, content-type',
+  } as const;
 }
+
+export const corsHeaders = getCorsHeaders();

--- a/supabase/functions/monitoring-alerts/index.ts
+++ b/supabase/functions/monitoring-alerts/index.ts
@@ -1,10 +1,17 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/cors.ts';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+function isAuthorized(req: Request): boolean {
+  const headerKey =
+    req.headers.get('apikey') ||
+    req.headers.get('Authorization')?.replace('Bearer ', '');
+
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+
+  return !!headerKey && (headerKey === serviceKey || headerKey === anonKey);
+}
 
 interface HealthCheckResult {
   service: string;
@@ -141,6 +148,40 @@ async function sendDiscordAlert(alert: AlertPayload) {
   }
 }
 
+async function sendTeamsAlert(alert: AlertPayload) {
+  const webhookUrl = Deno.env.get('TEAMS_WEBHOOK_URL');
+  if (!webhookUrl) return;
+
+  const message = {
+    '@type': 'MessageCard',
+    '@context': 'https://schema.org/extensions',
+    summary: `${alert.type.toUpperCase()} - ${alert.service}`,
+    themeColor:
+      alert.severity === 'critical'
+        ? 'E81123'
+        : alert.severity === 'high'
+        ? 'F2C744'
+        : '107C10',
+    sections: [
+      {
+        activityTitle: alert.service,
+        activitySubtitle: new Date().toISOString(),
+        text: alert.message,
+      },
+    ],
+  };
+
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(message),
+    });
+  } catch (error) {
+    console.error('Failed to send Teams alert:', error);
+  }
+}
+
 async function logIncident(alert: AlertPayload) {
   try {
     const { error } = await supabase
@@ -164,8 +205,17 @@ async function logIncident(alert: AlertPayload) {
 }
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req.headers.get('Origin'));
+
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (!isAuthorized(req)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
   }
 
   try {
@@ -201,7 +251,8 @@ serve(async (req) => {
             await Promise.all([
               sendSlackAlert(alert),
               sendDiscordAlert(alert),
-              logIncident(alert)
+              sendTeamsAlert(alert),
+              logIncident(alert),
             ]);
           }
         }
@@ -224,7 +275,8 @@ serve(async (req) => {
         await Promise.all([
           sendSlackAlert(alert),
           sendDiscordAlert(alert),
-          logIncident(alert)
+          sendTeamsAlert(alert),
+          logIncident(alert),
         ]);
 
         return new Response(JSON.stringify({ 


### PR DESCRIPTION
## Summary
- restrict CORS access to origins defined in `ALLOWED_ORIGINS`
- send monitoring alerts to Slack, Discord, and Teams using webhook env vars
- enforce Supabase key validation before executing monitoring actions

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a86fa08988832d8c5fd21d8745c72b