### PR TITLE
Add migrations for items, tracks, and lyrics schema

### DIFF
--- a/sql/001_types_enums.sql
+++ b/sql/001_types_enums.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+  CREATE TYPE public.music_mode AS ENUM ('A', 'B', 'AB');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE DOMAIN public.ms AS integer CHECK (VALUE >= 0);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;

--- a/sql/002_items_competences.sql
+++ b/sql/002_items_competences.sql
@@ -1,0 +1,150 @@
+CREATE TABLE IF NOT EXISTS public.items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug text UNIQUE NOT NULL,
+  title text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.items
+  ADD COLUMN IF NOT EXISTS id uuid;
+
+ALTER TABLE public.items
+  ADD COLUMN IF NOT EXISTS slug text;
+
+ALTER TABLE public.items
+  ADD COLUMN IF NOT EXISTS title text;
+
+ALTER TABLE public.items
+  ADD COLUMN IF NOT EXISTS description text;
+
+ALTER TABLE public.items
+  ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now();
+
+ALTER TABLE public.items
+  ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE public.items
+  ALTER COLUMN slug SET NOT NULL;
+
+ALTER TABLE public.items
+  ALTER COLUMN title SET NOT NULL;
+
+ALTER TABLE public.items
+  ALTER COLUMN created_at SET DEFAULT now();
+
+ALTER TABLE public.items
+  ALTER COLUMN created_at SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE public.items
+    ADD CONSTRAINT items_pkey PRIMARY KEY (id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.items
+    ADD CONSTRAINT items_slug_key UNIQUE (slug);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS public.item_competences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id uuid NOT NULL REFERENCES public.items(id) ON DELETE CASCADE,
+  rang text NOT NULL,
+  label text NOT NULL,
+  idx int NOT NULL DEFAULT 0
+);
+
+ALTER TABLE public.item_competences
+  ADD COLUMN IF NOT EXISTS id uuid;
+
+ALTER TABLE public.item_competences
+  ADD COLUMN IF NOT EXISTS item_id uuid;
+
+ALTER TABLE public.item_competences
+  ADD COLUMN IF NOT EXISTS rang text;
+
+ALTER TABLE public.item_competences
+  ADD COLUMN IF NOT EXISTS label text;
+
+ALTER TABLE public.item_competences
+  ADD COLUMN IF NOT EXISTS idx int DEFAULT 0;
+
+ALTER TABLE public.item_competences
+  ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE public.item_competences
+  ALTER COLUMN item_id SET NOT NULL;
+
+ALTER TABLE public.item_competences
+  ALTER COLUMN rang SET NOT NULL;
+
+ALTER TABLE public.item_competences
+  ALTER COLUMN label SET NOT NULL;
+
+ALTER TABLE public.item_competences
+  ALTER COLUMN idx SET DEFAULT 0;
+
+ALTER TABLE public.item_competences
+  ALTER COLUMN idx SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE public.item_competences
+    ADD CONSTRAINT item_competences_pkey PRIMARY KEY (id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.item_competences
+    ADD CONSTRAINT item_competences_rang_check CHECK (rang IN ('A', 'B'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.item_competences
+    ADD CONSTRAINT item_competences_item_id_fkey FOREIGN KEY (item_id) REFERENCES public.items(id) ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.item_competences
+    ADD CONSTRAINT item_competences_unique UNIQUE (item_id, rang, idx);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+CREATE OR REPLACE VIEW public.item_with_competences AS
+SELECT
+  i.id AS item_id,
+  i.slug,
+  i.title,
+  i.description,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object('rang', c.rang, 'idx', c.idx, 'label', c.label)
+      ORDER BY c.rang, c.idx
+    )
+    FILTER (WHERE c.id IS NOT NULL),
+    '[]'::jsonb
+  ) AS competences
+FROM public.items i
+LEFT JOIN public.item_competences c ON c.item_id = i.id
+GROUP BY i.id;

--- a/sql/003_generated_music_tracks.sql
+++ b/sql/003_generated_music_tracks.sql
@@ -1,0 +1,137 @@
+CREATE TABLE IF NOT EXISTS public.generated_music_tracks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id uuid NOT NULL,
+  item_id uuid NOT NULL REFERENCES public.items(id) ON DELETE CASCADE,
+  mode public.music_mode NOT NULL,
+  style text NOT NULL,
+  duration_ms public.ms,
+  status text NOT NULL DEFAULT 'pending',
+  suno_job_id text,
+  openai_prompt_hash text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS id uuid;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS owner_id uuid;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS item_id uuid;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS mode public.music_mode;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS style text;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS duration_ms public.ms;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending';
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS suno_job_id text;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS openai_prompt_hash text;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now();
+
+ALTER TABLE public.generated_music_tracks
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN owner_id SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN item_id SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN mode SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN style SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN status SET DEFAULT 'pending';
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN status SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN metadata SET DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN metadata SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN created_at SET DEFAULT now();
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN created_at SET NOT NULL;
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN updated_at SET DEFAULT now();
+
+ALTER TABLE public.generated_music_tracks
+  ALTER COLUMN updated_at SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE public.generated_music_tracks
+    ADD CONSTRAINT generated_music_tracks_pkey PRIMARY KEY (id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.generated_music_tracks
+    ADD CONSTRAINT generated_music_tracks_item_id_fkey FOREIGN KEY (item_id) REFERENCES public.items(id) ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.generated_music_tracks
+    ADD CONSTRAINT generated_music_tracks_status_check CHECK (status IN ('pending', 'processing', 'ready', 'failed'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_gmt_owner
+  ON public.generated_music_tracks(owner_id);
+
+CREATE INDEX IF NOT EXISTS idx_gmt_item
+  ON public.generated_music_tracks(item_id);
+
+CREATE INDEX IF NOT EXISTS idx_gmt_status
+  ON public.generated_music_tracks(status);
+
+CREATE OR REPLACE FUNCTION public.set_updated_at() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_gmt_updated ON public.generated_music_tracks;
+CREATE TRIGGER trg_gmt_updated
+BEFORE UPDATE ON public.generated_music_tracks
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();

--- a/sql/004_lyrics_segments.sql
+++ b/sql/004_lyrics_segments.sql
@@ -1,0 +1,102 @@
+CREATE TABLE IF NOT EXISTS public.lyrics_segments (
+  id bigserial PRIMARY KEY,
+  track_id uuid NOT NULL REFERENCES public.generated_music_tracks(id) ON DELETE CASCADE,
+  item_id uuid NOT NULL REFERENCES public.items(id) ON DELETE CASCADE,
+  idx int NOT NULL,
+  start_ms public.ms NOT NULL,
+  end_ms public.ms NOT NULL,
+  text text NOT NULL,
+  role text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (end_ms > start_ms)
+);
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS track_id uuid;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS item_id uuid;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS idx int;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS start_ms public.ms;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS end_ms public.ms;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS text text;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS role text;
+
+ALTER TABLE public.lyrics_segments
+  ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now();
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN track_id SET NOT NULL;
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN item_id SET NOT NULL;
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN idx SET NOT NULL;
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN start_ms SET NOT NULL;
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN end_ms SET NOT NULL;
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN text SET NOT NULL;
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN created_at SET DEFAULT now();
+
+ALTER TABLE public.lyrics_segments
+  ALTER COLUMN created_at SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE public.lyrics_segments
+    ADD CONSTRAINT lyrics_segments_pkey PRIMARY KEY (id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.lyrics_segments
+    ADD CONSTRAINT lyrics_segments_track_id_fkey FOREIGN KEY (track_id) REFERENCES public.generated_music_tracks(id) ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.lyrics_segments
+    ADD CONSTRAINT lyrics_segments_item_id_fkey FOREIGN KEY (item_id) REFERENCES public.items(id) ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.lyrics_segments
+    ADD CONSTRAINT lyrics_segments_end_after_start CHECK (end_ms > start_ms);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_lyrics_segments_track_idx
+  ON public.lyrics_segments(track_id, idx);
+
+CREATE INDEX IF NOT EXISTS idx_lyrics_segments_track_start
+  ON public.lyrics_segments(track_id, start_ms);

--- a/sql/007_validation_struct.sql
+++ b/sql/007_validation_struct.sql
@@ -1,0 +1,30 @@
+-- Items présents ?
+SELECT COUNT(*) AS total_items FROM public.items;
+
+-- Items sans compétences ?
+SELECT i.id, i.slug
+FROM public.items i
+LEFT JOIN public.item_competences c ON c.item_id = i.id
+GROUP BY i.id
+HAVING COUNT(c.id) = 0;
+
+-- Compteurs A/B par item (détecter manques)
+SELECT i.id, i.slug,
+  SUM((c.rang = 'A')::int) AS a_count,
+  SUM((c.rang = 'B')::int) AS b_count
+FROM public.items i
+LEFT JOIN public.item_competences c ON c.item_id = i.id
+GROUP BY i.id;
+
+-- Tracks incomplets
+SELECT * FROM public.generated_music_tracks
+WHERE owner_id IS NULL OR item_id IS NULL OR mode IS NULL OR style IS NULL;
+
+-- Segments invalides (timecodes)
+SELECT * FROM public.lyrics_segments WHERE end_ms <= start_ms;
+
+-- Doublons d'idx sur un track
+SELECT track_id, idx, COUNT(*)
+FROM public.lyrics_segments
+GROUP BY track_id, idx
+HAVING COUNT(*) > 1;


### PR DESCRIPTION
## Summary
- add idempotent enum and domain definitions for music generation metadata
- create and harden items, item_competences, generated music track, and lyrics segment schemas with supporting constraints
- expose an aggregated item_with_competences view and provide a structural validation query script

## Testing
- Not run (database environment not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd299e1700832d8369c4a275b7913a