### PR TITLE
Add Supabase RLS policies for catalog and user tables

### DIFF
--- a/sql/005_grants.sql
+++ b/sql/005_grants.sql
@@ -1,0 +1,9 @@
+-- Minimal privileges for Supabase roles with RLS enforced
+GRANT SELECT ON public.items, public.item_competences TO authenticated;
+-- GRANT SELECT ON public.items, public.item_competences TO anon; -- optional public read access
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.generated_music_tracks TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.lyrics_segments        TO authenticated;
+
+GRANT ALL ON public.generated_music_tracks, public.lyrics_segments TO service_role;
+GRANT ALL ON public.items, public.item_competences                TO service_role;

--- a/sql/005_rls_enable.sql
+++ b/sql/005_rls_enable.sql
@@ -1,0 +1,6 @@
+-- Enable Row Level Security on reference and user data tables
+ALTER TABLE public.items            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.item_competences ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.generated_music_tracks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.lyrics_segments        ENABLE ROW LEVEL SECURITY;

--- a/sql/005_rls_policies_catalog.sql
+++ b/sql/005_rls_policies_catalog.sql
@@ -1,0 +1,13 @@
+-- Policies granting read access on reference tables
+DROP POLICY IF EXISTS items_select ON public.items;
+CREATE POLICY items_select ON public.items
+  FOR SELECT TO authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS ic_select ON public.item_competences;
+CREATE POLICY ic_select ON public.item_competences
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Optional public read access (uncomment if anonymous users should read catalogs)
+-- GRANT SELECT ON public.items, public.item_competences TO anon;

--- a/sql/005_rls_policies_segments.sql
+++ b/sql/005_rls_policies_segments.sql
@@ -1,0 +1,20 @@
+-- Row Level Security policies for lyrics segments linked to tracks
+DROP POLICY IF EXISTS ls_select ON public.lyrics_segments;
+CREATE POLICY ls_select ON public.lyrics_segments
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.generated_music_tracks t
+    WHERE t.id = track_id AND t.owner_id = auth.uid()
+  ));
+
+DROP POLICY IF EXISTS ls_mut ON public.lyrics_segments;
+CREATE POLICY ls_mut ON public.lyrics_segments
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.generated_music_tracks t
+    WHERE t.id = track_id AND t.owner_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.generated_music_tracks t
+    WHERE t.id = track_id AND t.owner_id = auth.uid()
+  ));

--- a/sql/005_rls_policies_tracks.sql
+++ b/sql/005_rls_policies_tracks.sql
@@ -1,0 +1,21 @@
+-- Row Level Security policies for generated music tracks
+DROP POLICY IF EXISTS gmt_select ON public.generated_music_tracks;
+CREATE POLICY gmt_select ON public.generated_music_tracks
+  FOR SELECT TO authenticated
+  USING (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS gmt_insert ON public.generated_music_tracks;
+CREATE POLICY gmt_insert ON public.generated_music_tracks
+  FOR INSERT TO authenticated
+  WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS gmt_update ON public.generated_music_tracks;
+CREATE POLICY gmt_update ON public.generated_music_tracks
+  FOR UPDATE TO authenticated
+  USING (owner_id = auth.uid())
+  WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS gmt_delete ON public.generated_music_tracks;
+CREATE POLICY gmt_delete ON public.generated_music_tracks
+  FOR DELETE TO authenticated
+  USING (owner_id = auth.uid());


### PR DESCRIPTION
## Summary
- enable RLS on catalog and user data tables
- add row level security policies covering catalog, tracks, and lyric segments
- configure grants for authenticated, anon (commented), and service roles

## Testing
- not run (SQL migrations only)


------
https://chatgpt.com/codex/tasks/task_e_68cd2a2927b4832db67cff67ddb7984f