### PR TITLE
feat: aggregate item competences view

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -9357,11 +9357,7 @@ export type Database = {
       }
       item_with_competences: {
         Row: {
-          competence_description: string | null
-          competence_id: string | null
-          competence_rang: string | null
-          competence_rubrique: string | null
-          competence_title: string | null
+          competences: Json | null
           item_code: string
           item_id: string
           slug: string | null

--- a/src/services/music/itemPromptService.ts
+++ b/src/services/music/itemPromptService.ts
@@ -87,11 +87,7 @@ export async function loadItemContext(options: {
         return null;
       }
       const rang = normaliseMode(competence?.rang ?? null) ?? 'A';
-      const candidateIdx =
-        typeof competence?.idx === 'number'
-          ? competence.idx
-          : Number.parseInt(String(competence?.idx ?? ''), 10);
-      const idx = Number.isFinite(candidateIdx) ? Math.max(0, Math.trunc(candidateIdx)) : index + 1;
+      const idx = competence?.idx ?? index + 1;
       return {
         rang,
         idx,

--- a/src/services/music/itemPromptService.ts
+++ b/src/services/music/itemPromptService.ts
@@ -8,19 +8,17 @@ interface ItemWithCompetenceRow {
   item_code: string;
   title: string;
   slug: string | null;
-  competence_id: string | null;
-  competence_title: string | null;
-  competence_description: string | null;
-  competence_rang: string | null;
-  competence_rubrique: string | null;
+  competences: Array<{
+    rang?: string | null;
+    idx?: number | null;
+    label?: string | null;
+  }> | null;
 }
 
 export interface ItemCompetenceSummary {
-  id: string;
   rang: MusicMode;
-  rubrique?: string | null;
-  title?: string | null;
-  description?: string | null;
+  idx: number;
+  label: string;
 }
 
 export interface ItemContext {
@@ -64,20 +62,9 @@ export async function loadItemContext(options: {
 }): Promise<ItemContext> {
   const query = supabase
     .from('item_with_competences')
-    .select(
-      [
-        'item_id',
-        'item_code',
-        'title',
-        'slug',
-        'competence_id',
-        'competence_title',
-        'competence_description',
-        'competence_rang',
-        'competence_rubrique',
-      ].join(','),
-    )
-    .eq('item_code', options.itemCode);
+    .select(['item_id', 'item_code', 'title', 'slug', 'competences'].join(','))
+    .eq('item_code', options.itemCode)
+    .limit(1);
 
   if (options.itemId) {
     query.eq('item_id', options.itemId);
@@ -92,15 +79,26 @@ export async function loadItemContext(options: {
   }
 
   const [first] = data as ItemWithCompetenceRow[];
-  const competences = (data as ItemWithCompetenceRow[])
-    .filter((row) => Boolean(row.competence_id || row.competence_title || row.competence_description))
-    .map((row) => ({
-      id: row.competence_id ?? `${row.item_id}-${row.competence_title ?? 'competence'}`,
-      rang: normaliseMode(row.competence_rang) ?? 'A',
-      rubrique: row.competence_rubrique,
-      title: row.competence_title,
-      description: row.competence_description,
-    } satisfies ItemCompetenceSummary));
+  const rawCompetences = Array.isArray(first.competences) ? first.competences : [];
+  const competences = rawCompetences
+    .map((competence, index) => {
+      const label = typeof competence?.label === 'string' ? competence.label.trim() : '';
+      if (!label) {
+        return null;
+      }
+      const rang = normaliseMode(competence?.rang ?? null) ?? 'A';
+      const candidateIdx =
+        typeof competence?.idx === 'number'
+          ? competence.idx
+          : Number.parseInt(String(competence?.idx ?? ''), 10);
+      const idx = Number.isFinite(candidateIdx) ? Math.max(0, Math.trunc(candidateIdx)) : index + 1;
+      return {
+        rang,
+        idx,
+        label,
+      } satisfies ItemCompetenceSummary;
+    })
+    .filter((entry): entry is ItemCompetenceSummary => entry !== null);
 
   return {
     itemId: first.item_id,
@@ -119,19 +117,9 @@ export function summariseCompetences(context: ItemContext, mode: MusicMode): str
     if (!targetedModes.includes(competence.rang)) {
       return;
     }
-    const fragments: string[] = [];
-    if (competence.rubrique) {
-      fragments.push(competence.rubrique.trim());
-    }
-    if (competence.title) {
-      fragments.push(competence.title.trim());
-    }
-    if (competence.description) {
-      fragments.push(competence.description.trim());
-    }
-    const summary = fragments.join(' – ').replace(/\s+/g, ' ').trim();
+    const summary = competence.label.replace(/\s+/g, ' ').trim();
     if (summary) {
-      uniqueEntries.set(summary.toLowerCase(), summary);
+      uniqueEntries.set(`${competence.rang}-${competence.idx}-${summary.toLowerCase()}`, summary);
     }
   });
 

--- a/src/services/music/itemPromptService.ts
+++ b/src/services/music/itemPromptService.ts
@@ -119,7 +119,7 @@ export function summariseCompetences(context: ItemContext, mode: MusicMode): str
     }
     const summary = competence.label.replace(/\s+/g, ' ').trim();
     if (summary) {
-      uniqueEntries.set(`${competence.rang}-${competence.idx}-${summary.toLowerCase()}`, summary);
+      uniqueEntries.set(`${competence.rang}-${summary.toLowerCase()}`, summary);
     }
   });
 

--- a/supabase/migrations/20251020100000-item-with-competences-view.sql
+++ b/supabase/migrations/20251020100000-item-with-competences-view.sql
@@ -1,0 +1,68 @@
+-- MMG-DB-01: Consolidated item + competences view for API consumption
+
+-- Ensure performant lookups when normalising item codes
+CREATE INDEX IF NOT EXISTS idx_oic_competences_item_code_rang_order
+ON public.oic_competences (
+  lpad(nullif(regexp_replace(item_parent, '[^0-9]', '', 'g'), ''), 3, '0'),
+  rang,
+  coalesce(ordre, 0)
+);
+
+DROP VIEW IF EXISTS public.item_with_competences;
+
+CREATE VIEW public.item_with_competences AS
+WITH items AS (
+  SELECT
+    i.id AS item_id,
+    i.item_code,
+    i.slug,
+    i.title,
+    lpad(nullif(regexp_replace(i.item_code, '[^0-9]', '', 'g'), ''), 3, '0') AS normalized_code
+  FROM public.edn_items_immersive i
+),
+competences AS (
+  SELECT
+    base.normalized_code,
+    base.rang,
+    CASE
+      WHEN base.ordre IS NOT NULL AND base.ordre > 0 THEN base.ordre
+      ELSE row_number() OVER (
+        PARTITION BY base.normalized_code, base.rang
+        ORDER BY base.objectif_id
+      )
+    END AS idx,
+    base.label
+  FROM (
+    SELECT
+      lpad(nullif(regexp_replace(c.item_parent, '[^0-9]', '', 'g'), ''), 3, '0') AS normalized_code,
+      c.rang,
+      c.ordre,
+      c.objectif_id,
+      coalesce(nullif(btrim(c.intitule), ''), nullif(btrim(c.description), ''), c.objectif_id) AS label
+    FROM public.oic_competences c
+  ) base
+)
+SELECT
+  it.item_id,
+  it.item_code,
+  it.slug,
+  it.title,
+  coalesce(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'rang', comp.rang,
+          'idx', comp.idx,
+          'label', comp.label
+        )
+        ORDER BY comp.rang, comp.idx, comp.label
+      )
+      FROM competences comp
+      WHERE comp.normalized_code = it.normalized_code AND comp.label IS NOT NULL
+    ),
+    '[]'::jsonb
+  ) AS competences
+FROM items it
+ORDER BY it.item_code;
+
+COMMENT ON VIEW public.item_with_competences IS 'EDN item catalogue with aggregated OIC competences (rang A/B).';


### PR DESCRIPTION
## Summary
- add a Supabase migration that rebuilds `item_with_competences` as a per-item view with aggregated competence JSON and a supporting index
- sync generated Supabase types with the new view contract
- update the music item prompt service to consume the aggregated competence payload

## Testing
- pnpm lint *(fails: missing @eslint/js dependency in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cd93d390832da8c400b458b2f274