### PR TITLE
feat: surface items completeness metrics

### DIFF
--- a/sql/materialized_views.sql
+++ b/sql/materialized_views.sql
@@ -1,0 +1,88 @@
+-- Materialized views definition snapshots
+
+-- Items completeness view for EDN items
+DROP MATERIALIZED VIEW IF EXISTS public.items_completeness;
+
+CREATE MATERIALIZED VIEW public.items_completeness AS
+WITH edn_items AS (
+  SELECT
+    item_code,
+    CASE
+      WHEN item_code ~ '^IC-[0-9]+$' THEN LPAD(SUBSTRING(item_code FROM 'IC-([0-9]+)'), 3, '0')
+      ELSE NULL
+    END AS item_key,
+    tableau_rang_a,
+    tableau_rang_b,
+    competences_oic_rang_a,
+    competences_oic_rang_b
+  FROM public.edn_items_complete
+),
+expected AS (
+  SELECT
+    LPAD(item_parent, 3, '0') AS item_key,
+    COUNT(*) AS expected_total
+  FROM public.backup_oic_competences
+  GROUP BY 1
+),
+unified AS (
+  SELECT
+    COALESCE(e.item_code, 'IC-' || ex.item_key) AS item_code,
+    COALESCE(e.item_key, ex.item_key) AS item_key,
+    e.tableau_rang_a,
+    e.tableau_rang_b,
+    e.competences_oic_rang_a,
+    e.competences_oic_rang_b,
+    COALESCE(ex.expected_total, 0) AS expected_total
+  FROM expected ex
+  FULL OUTER JOIN edn_items e ON e.item_key = ex.item_key
+)
+SELECT
+  item_code AS item_id,
+  (tableau_rang_a IS NOT NULL) AS has_a,
+  (tableau_rang_b IS NOT NULL) AS has_b,
+  (
+    CASE
+      WHEN competences_oic_rang_a IS NULL OR jsonb_typeof(competences_oic_rang_a) <> 'array' THEN 0
+      ELSE jsonb_array_length(competences_oic_rang_a)
+    END
+    +
+    CASE
+      WHEN competences_oic_rang_b IS NULL OR jsonb_typeof(competences_oic_rang_b) <> 'array' THEN 0
+      ELSE jsonb_array_length(competences_oic_rang_b)
+    END
+  ) AS oic_count,
+  expected_total AS oic_expected,
+  CASE
+    WHEN (tableau_rang_a IS NULL AND tableau_rang_b IS NULL AND
+          (
+            CASE
+              WHEN competences_oic_rang_a IS NULL OR jsonb_typeof(competences_oic_rang_a) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_a)
+            END
+            +
+            CASE
+              WHEN competences_oic_rang_b IS NULL OR jsonb_typeof(competences_oic_rang_b) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_b)
+            END
+          ) = 0) THEN 'missing'
+    WHEN (tableau_rang_a IS NOT NULL AND tableau_rang_b IS NOT NULL AND
+          (expected_total = 0 OR (
+            CASE
+              WHEN competences_oic_rang_a IS NULL OR jsonb_typeof(competences_oic_rang_a) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_a)
+            END
+            +
+            CASE
+              WHEN competences_oic_rang_b IS NULL OR jsonb_typeof(competences_oic_rang_b) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_b)
+            END
+          ) >= expected_total)) THEN 'complete'
+    ELSE 'partial'
+  END AS status
+FROM unified
+WHERE item_code IS NOT NULL
+ORDER BY item_code
+WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_completeness_item_id
+  ON public.items_completeness (item_id);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const PlatformOverview = lazy(() => import("./pages/PlatformOverview"));
 const PlatformComplete = lazy(() => import("./pages/PlatformComplete"));
 const QuickStart = lazy(() => import("./pages/QuickStart"));
 const Generator = lazy(() => import("./pages/Generator"));
+const ItemsCompleteness = lazy(() => import("./pages/ItemsCompleteness"));
 const MeditationCenter = lazy(() => import("./pages/MeditationCenter"));
 const UserSettings = lazy(() => import("./pages/UserSettings"));
 const DuplicateAnalysis = lazy(() => import("./pages/DuplicateAnalysis"));
@@ -208,6 +209,7 @@ const AppWithUX = () => {
                                               <Route path="/" element={<OptimizedIndex />} />
                                               <Route path="/platform" element={<PlatformOverview />} />
                                               <Route path="/generator" element={<Generator />} />
+                                              <Route path="/items" element={<ItemsCompleteness />} />
                                               <Route path="/meditation/*" element={<MeditationCenter />} />
                                               
                                               {/* ⚡ DASHBOARD & ANALYTICS - Version unifiée */}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4007,6 +4007,17 @@ export type Database = {
           },
         ]
       }
+      items_completeness: {
+        Row: {
+          item_id: string
+          has_a: boolean
+          has_b: boolean
+          oic_count: number
+          oic_expected: number
+          status: string
+        }
+        Relationships: []
+      }
       items_completeness_history: {
         Row: {
           completeness_score: number
@@ -10482,6 +10493,32 @@ export type Database = {
       med_mng_track_listening: {
         Args: { p_listen_duration?: number; p_song_id: string }
         Returns: undefined
+      }
+      get_items_completeness: {
+        Args: {
+          p_status?: string | null
+          p_limit?: number | null
+          p_offset?: number | null
+        }
+        Returns: {
+          item_id: string
+          has_a: boolean
+          has_b: boolean
+          oic_count: number
+          oic_expected: number
+          status: string
+        }[]
+      }
+      get_items_completeness_summary: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          total_items: number
+          complete_items: number
+          partial_items: number
+          missing_items: number
+          completion_rate: number
+          average_oic_ratio: number
+        }[]
       }
       merge_all_tables_into_complete: {
         Args: Record<PropertyKey, never>

--- a/src/pages/ItemsCompleteness.tsx
+++ b/src/pages/ItemsCompleteness.tsx
@@ -1,0 +1,356 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { CheckCircle, Loader2, RefreshCw, Search, XCircle } from 'lucide-react';
+
+interface ItemCompletenessRow {
+  item_id: string;
+  has_a: boolean;
+  has_b: boolean;
+  oic_count: number;
+  oic_expected: number;
+  status: 'complete' | 'partial' | 'missing' | string;
+}
+
+interface ItemsCompletenessSummary {
+  total_items: number;
+  complete_items: number;
+  partial_items: number;
+  missing_items: number;
+  completion_rate: number;
+  average_oic_ratio: number;
+}
+
+type StatusFilter = 'all' | 'complete' | 'partial' | 'missing';
+
+const STATUS_LABELS: Record<Exclude<StatusFilter, 'all'>, string> = {
+  complete: 'Complets',
+  partial: 'Partiels',
+  missing: 'Manquants',
+};
+
+const ItemsCompleteness = () => {
+  const { toast } = useToast();
+  const [items, setItems] = useState<ItemCompletenessRow[]>([]);
+  const [summary, setSummary] = useState<ItemsCompletenessSummary | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const computeRatio = useCallback((row: ItemCompletenessRow) => {
+    if (row.oic_expected <= 0) {
+      return row.oic_count > 0 || row.status === 'complete' ? 100 : 0;
+    }
+
+    const ratio = Math.round((row.oic_count / row.oic_expected) * 100);
+    return Math.min(100, Math.max(0, ratio));
+  }, []);
+
+  const fetchCompleteness = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const { data: viewRows, error: viewError } = await supabase.rpc('get_items_completeness', {
+        p_status: statusFilter === 'all' ? null : statusFilter,
+        p_limit: 500,
+        p_offset: 0,
+      });
+
+      if (viewError) {
+        throw viewError;
+      }
+
+      setItems(viewRows ?? []);
+
+      const { data: summaryRows, error: summaryError } = await supabase.rpc(
+        'get_items_completeness_summary',
+      );
+
+      if (summaryError) {
+        throw summaryError;
+      }
+
+      const summaryRow = Array.isArray(summaryRows) ? summaryRows[0] ?? null : summaryRows;
+      setSummary(summaryRow as ItemsCompletenessSummary | null);
+
+      if (!viewRows || viewRows.length === 0) {
+        toast({
+          title: 'Aucun item trouvé',
+          description: 'Aucun item ne correspond au filtre sélectionné.',
+        });
+      }
+    } catch (fetchError) {
+      console.error('❌ Failed to load items completeness:', fetchError);
+      setError("Impossible de charger les données de complétude");
+      toast({
+        title: 'Erreur de chargement',
+        description: "Impossible de charger la complétude des items.",
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [statusFilter, toast]);
+
+  useEffect(() => {
+    fetchCompleteness();
+  }, [fetchCompleteness]);
+
+  const filteredItems = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return (items ?? [])
+      .filter((item) => {
+        if (!normalizedSearch) return true;
+        return item.item_id.toLowerCase().includes(normalizedSearch);
+      })
+      .sort((a, b) => a.item_id.localeCompare(b.item_id));
+  }, [items, searchTerm]);
+
+  const displayedSummary = useMemo(() => {
+    if (filteredItems.length === 0) {
+      return {
+        withA: 0,
+        withB: 0,
+        averageRatio: 0,
+      };
+    }
+
+    const withA = filteredItems.filter((item) => item.has_a).length;
+    const withB = filteredItems.filter((item) => item.has_b).length;
+    const averageRatio = Math.round(
+      filteredItems.reduce((total, item) => total + computeRatio(item), 0) /
+        filteredItems.length,
+    );
+
+    return { withA, withB, averageRatio };
+  }, [filteredItems, computeRatio]);
+
+  const renderStatusBadge = (status: string) => {
+    const label = status in STATUS_LABELS ? STATUS_LABELS[status as keyof typeof STATUS_LABELS] : status;
+
+    switch (status) {
+      case 'complete':
+        return (
+          <Badge className="capitalize border-green-200 bg-green-100 text-green-700 hover:bg-green-100">
+            {label}
+          </Badge>
+        );
+      case 'missing':
+        return (
+          <Badge variant="destructive" className="capitalize">
+            {label}
+          </Badge>
+        );
+      default:
+        return (
+          <Badge variant="secondary" className="capitalize">
+            {label}
+          </Badge>
+        );
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-10 space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Complétude des items EDN</h1>
+          <p className="text-muted-foreground">
+            Visualisez la présence des tableaux Rang A/B et la progression des compétences OIC intégrées.
+          </p>
+        </div>
+        <Button onClick={fetchCompleteness} disabled={isLoading} className="self-start gap-2">
+          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          Actualiser
+        </Button>
+      </div>
+
+      {summary && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Total items</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">{summary.total_items}</div>
+              <p className="text-xs text-muted-foreground">Items suivis dans la plateforme</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Items complets</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold text-green-600">{summary.complete_items}</div>
+              <p className="text-xs text-muted-foreground">
+                {summary.completion_rate}% de complétude globale
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Items à suivre</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold text-amber-600">{summary.partial_items}</div>
+              <p className="text-xs text-muted-foreground">Tableaux ou OIC partiels</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Ratio OIC moyen</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-baseline gap-2">
+                <span className="text-2xl font-semibold">{summary.average_oic_ratio}%</span>
+              </div>
+              <Progress value={summary.average_oic_ratio} className="mt-2" />
+              <p className="text-xs text-muted-foreground">Compétences intégrées vs attendues</p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <Card>
+        <CardHeader className="pb-4">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-center gap-3">
+              <Tabs value={statusFilter} onValueChange={(value) => setStatusFilter(value as StatusFilter)}>
+                <TabsList>
+                  <TabsTrigger value="all">Tous</TabsTrigger>
+                  <TabsTrigger value="complete">Complets</TabsTrigger>
+                  <TabsTrigger value="partial">Partiels</TabsTrigger>
+                  <TabsTrigger value="missing">Manquants</TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <div className="text-sm text-muted-foreground">
+                {filteredItems.length} items affichés · {displayedSummary.withA} avec Rang A ·{' '}
+                {displayedSummary.withB} avec Rang B
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Search className="h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Rechercher un item (IC-001)"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                className="w-56"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <div>
+              Ratio OIC moyen (filtre): <span className="font-medium">{displayedSummary.averageRatio}%</span>
+            </div>
+            {isLoading && (
+              <div className="flex items-center gap-2 text-primary">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Chargement des données…
+              </div>
+            )}
+          </div>
+
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[110px]">Item</TableHead>
+                  <TableHead>Rang A</TableHead>
+                  <TableHead>Rang B</TableHead>
+                  <TableHead>OIC intégrées</TableHead>
+                  <TableHead>OIC attendues</TableHead>
+                  <TableHead>Ratio</TableHead>
+                  <TableHead>Statut</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.map((item) => {
+                  const ratio = computeRatio(item);
+                  return (
+                    <TableRow key={item.item_id}>
+                      <TableCell className="font-mono font-medium">{item.item_id}</TableCell>
+                      <TableCell>
+                        {item.has_a ? (
+                          <span className="inline-flex items-center gap-1 text-sm text-green-600">
+                            <CheckCircle className="h-4 w-4" />
+                            Présent
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+                            <XCircle className="h-4 w-4" />
+                            Manquant
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {item.has_b ? (
+                          <span className="inline-flex items-center gap-1 text-sm text-green-600">
+                            <CheckCircle className="h-4 w-4" />
+                            Présent
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+                            <XCircle className="h-4 w-4" />
+                            Manquant
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>{item.oic_count}</TableCell>
+                      <TableCell>{item.oic_expected}</TableCell>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <div className="flex items-center justify-between text-xs">
+                            <span>{ratio}%</span>
+                            <span className="text-muted-foreground">
+                              {item.oic_expected > 0
+                                ? `${item.oic_count}/${item.oic_expected}`
+                                : `${item.oic_count}`}
+                            </span>
+                          </div>
+                          <Progress value={ratio} className="h-2" />
+                        </div>
+                      </TableCell>
+                      <TableCell>{renderStatusBadge(item.status)}</TableCell>
+                    </TableRow>
+                  );
+                })}
+
+                {filteredItems.length === 0 && !isLoading && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
+                      Aucun item ne correspond aux filtres actuels.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ItemsCompleteness;

--- a/supabase/functions/items-completeness-api/index.ts
+++ b/supabase/functions/items-completeness-api/index.ts
@@ -113,6 +113,52 @@ serve(async (req) => {
       });
     }
 
+    // GET /items-completeness-api?action=get-overview&status=partial
+    if (req.method === 'GET' && action === 'get-overview') {
+      const status = url.searchParams.get('status');
+      const limit = Math.min(
+        Math.max(parseInt(url.searchParams.get('limit') || '200', 10) || 200, 1),
+        1000
+      );
+      const offset = Math.max(parseInt(url.searchParams.get('offset') || '0', 10) || 0, 0);
+
+      const allowedStatuses = ['complete', 'partial', 'missing'];
+      const statusFilter = status && allowedStatuses.includes(status) ? status : null;
+
+      const { data: items, error: itemsError } = await supabase.rpc('get_items_completeness', {
+        p_status: statusFilter,
+        p_limit: limit,
+        p_offset: offset,
+      });
+
+      if (itemsError) {
+        console.error('❌ Error fetching items completeness:', itemsError);
+        throw itemsError;
+      }
+
+      const { data: summaryRows, error: summaryError } = await supabase.rpc(
+        'get_items_completeness_summary',
+      );
+
+      if (summaryError) {
+        console.error('❌ Error fetching completeness summary:', summaryError);
+        throw summaryError;
+      }
+
+      const summary = Array.isArray(summaryRows) ? summaryRows[0] ?? null : summaryRows;
+
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          items: items ?? [],
+          summary,
+        },
+        count: items?.length ?? 0,
+      }), {
+        headers: { ...corsHeaders, ...securityHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
     // GET /items-completeness-api?action=get-item-status&item_code=IC-1
     if (req.method === 'GET' && action === 'get-item-status') {
       const itemCode = url.searchParams.get('item_code');

--- a/supabase/migrations/20251020120000-items-completeness-materialized-view.sql
+++ b/supabase/migrations/20251020120000-items-completeness-materialized-view.sql
@@ -1,0 +1,206 @@
+-- Items completeness materialized view and refresh scheduling
+
+-- Ensure required extensions for scheduling are available
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Drop existing view if present to allow recreation
+DROP MATERIALIZED VIEW IF EXISTS public.items_completeness;
+
+-- Build canonical mapping for expected OIC competences by item
+CREATE MATERIALIZED VIEW public.items_completeness AS
+WITH edn_items AS (
+  SELECT
+    item_code,
+    CASE
+      WHEN item_code ~ '^IC-[0-9]+$' THEN LPAD(SUBSTRING(item_code FROM 'IC-([0-9]+)'), 3, '0')
+      ELSE NULL
+    END AS item_key,
+    tableau_rang_a,
+    tableau_rang_b,
+    competences_oic_rang_a,
+    competences_oic_rang_b
+  FROM public.edn_items_complete
+),
+expected AS (
+  SELECT
+    LPAD(item_parent, 3, '0') AS item_key,
+    COUNT(*) AS expected_total
+  FROM public.backup_oic_competences
+  GROUP BY 1
+),
+unified AS (
+  SELECT
+    COALESCE(e.item_code, 'IC-' || ex.item_key) AS item_code,
+    COALESCE(e.item_key, ex.item_key) AS item_key,
+    e.tableau_rang_a,
+    e.tableau_rang_b,
+    e.competences_oic_rang_a,
+    e.competences_oic_rang_b,
+    COALESCE(ex.expected_total, 0) AS expected_total
+  FROM expected ex
+  FULL OUTER JOIN edn_items e ON e.item_key = ex.item_key
+)
+SELECT
+  item_code AS item_id,
+  (tableau_rang_a IS NOT NULL) AS has_a,
+  (tableau_rang_b IS NOT NULL) AS has_b,
+  (
+    CASE
+      WHEN competences_oic_rang_a IS NULL OR jsonb_typeof(competences_oic_rang_a) <> 'array' THEN 0
+      ELSE jsonb_array_length(competences_oic_rang_a)
+    END
+    +
+    CASE
+      WHEN competences_oic_rang_b IS NULL OR jsonb_typeof(competences_oic_rang_b) <> 'array' THEN 0
+      ELSE jsonb_array_length(competences_oic_rang_b)
+    END
+  ) AS oic_count,
+  expected_total AS oic_expected,
+  CASE
+    WHEN (tableau_rang_a IS NULL AND tableau_rang_b IS NULL AND
+          (
+            CASE
+              WHEN competences_oic_rang_a IS NULL OR jsonb_typeof(competences_oic_rang_a) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_a)
+            END
+            +
+            CASE
+              WHEN competences_oic_rang_b IS NULL OR jsonb_typeof(competences_oic_rang_b) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_b)
+            END
+          ) = 0) THEN 'missing'
+    WHEN (tableau_rang_a IS NOT NULL AND tableau_rang_b IS NOT NULL AND
+          (expected_total = 0 OR (
+            CASE
+              WHEN competences_oic_rang_a IS NULL OR jsonb_typeof(competences_oic_rang_a) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_a)
+            END
+            +
+            CASE
+              WHEN competences_oic_rang_b IS NULL OR jsonb_typeof(competences_oic_rang_b) <> 'array' THEN 0
+              ELSE jsonb_array_length(competences_oic_rang_b)
+            END
+          ) >= expected_total)) THEN 'complete'
+    ELSE 'partial'
+  END AS status
+FROM unified
+WHERE item_code IS NOT NULL
+ORDER BY item_code
+WITH NO DATA;
+
+-- Index to accelerate lookups
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_completeness_item_id
+  ON public.items_completeness (item_id);
+
+COMMENT ON MATERIALIZED VIEW public.items_completeness IS 'Synthèse de la complétude des items EDN (tableaux rang A/B, OIC)';
+
+-- Populate data immediately after creation
+REFRESH MATERIALIZED VIEW public.items_completeness;
+
+-- Allow the API roles to read the materialized view
+GRANT SELECT ON TABLE public.items_completeness TO anon;
+GRANT SELECT ON TABLE public.items_completeness TO authenticated;
+GRANT SELECT ON TABLE public.items_completeness TO service_role;
+
+-- Helper to refresh the materialized view on demand
+CREATE OR REPLACE FUNCTION public.refresh_items_completeness()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY public.items_completeness;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.refresh_items_completeness() TO anon;
+GRANT EXECUTE ON FUNCTION public.refresh_items_completeness() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.refresh_items_completeness() TO service_role;
+
+-- RPC endpoint to expose the materialized view in a controlled way
+CREATE OR REPLACE FUNCTION public.get_items_completeness(
+  p_status text DEFAULT NULL,
+  p_limit integer DEFAULT 200,
+  p_offset integer DEFAULT 0
+)
+RETURNS TABLE(
+  item_id text,
+  has_a boolean,
+  has_b boolean,
+  oic_count integer,
+  oic_expected integer,
+  status text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT item_id, has_a, has_b, oic_count, oic_expected, status
+  FROM public.items_completeness
+  WHERE p_status IS NULL OR status = p_status
+  ORDER BY item_id
+  LIMIT GREATEST(p_limit, 0)
+  OFFSET GREATEST(p_offset, 0);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_items_completeness(text, integer, integer) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_items_completeness(text, integer, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_items_completeness(text, integer, integer) TO service_role;
+
+-- Summary helper for dashboards
+CREATE OR REPLACE FUNCTION public.get_items_completeness_summary()
+RETURNS TABLE(
+  total_items integer,
+  complete_items integer,
+  partial_items integer,
+  missing_items integer,
+  completion_rate numeric,
+  average_oic_ratio numeric
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    COUNT(*) AS total_items,
+    COUNT(*) FILTER (WHERE status = 'complete') AS complete_items,
+    COUNT(*) FILTER (WHERE status = 'partial') AS partial_items,
+    COUNT(*) FILTER (WHERE status = 'missing') AS missing_items,
+    CASE
+      WHEN COUNT(*) = 0 THEN 0
+      ELSE ROUND(COUNT(*) FILTER (WHERE status = 'complete')::numeric * 100 / COUNT(*), 1)
+    END AS completion_rate,
+    CASE
+      WHEN SUM(CASE WHEN oic_expected > 0 THEN 1 ELSE 0 END) = 0 THEN 0
+      ELSE ROUND(
+        SUM(
+          CASE
+            WHEN oic_expected > 0 THEN LEAST(oic_count::numeric / NULLIF(oic_expected, 0), 1)
+            ELSE 0
+          END
+        ) * 100 / NULLIF(SUM(CASE WHEN oic_expected > 0 THEN 1 ELSE 0 END), 0),
+        1
+      )
+    END AS average_oic_ratio
+  FROM public.items_completeness;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_items_completeness_summary() TO anon;
+GRANT EXECUTE ON FUNCTION public.get_items_completeness_summary() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_items_completeness_summary() TO service_role;
+
+-- Ensure the refresh job runs regularly after imports
+DO $$
+BEGIN
+  PERFORM cron.unschedule('refresh-items-completeness-hourly');
+EXCEPTION
+  WHEN OTHERS THEN NULL;
+END;
+$$;
+
+SELECT cron.schedule(
+  'refresh-items-completeness-hourly',
+  '5 * * * *',
+  'SELECT public.refresh_items_completeness()'
+);


### PR DESCRIPTION
## Summary
- add the `items_completeness` materialized view with helper RPCs and a scheduled refresh
- expose the new view through the items completeness edge function and supabase type definitions
- introduce a /items dashboard that visualises completeness signals in the app shell

## Testing
- npm run typecheck
- npm run lint *(fails: missing @eslint/js / npm install blocked by Storybook peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cda0fefc832d9dcbfc9d918ae1b6