### PR TITLE
feat: automate Supabase migrations in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,10 +106,61 @@ jobs:
           name: playwright-report
           path: playwright-report/
 
+  # 🗄️ DATABASE MIGRATIONS
+  db-migrate:
+    runs-on: ubuntu-latest
+    needs: [quality-checks, security-scan, e2e-tests]
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    steps:
+      - name: 🛒 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      - name: Determine target environment
+        id: target
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run staging database migrations
+        id: migrate_staging
+        if: steps.target.outputs.environment == 'staging'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: ./scripts/db_migrate.sh staging
+
+      - name: Run production database migrations
+        id: migrate_production
+        if: steps.target.outputs.environment == 'production'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_URL: ${{ secrets.PROD_SUPABASE_DB_URL }}
+        run: ./scripts/db_migrate.sh production
+
+      - name: Rollback staging database migrations
+        if: steps.migrate_staging.outcome == 'failure'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: ./scripts/db_rollback.sh staging
+
+      - name: Rollback production database migrations
+        if: steps.migrate_production.outcome == 'failure'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_URL: ${{ secrets.PROD_SUPABASE_DB_URL }}
+        run: ./scripts/db_rollback.sh production
+
   # 🏗️ BUILD & DEPLOY STAGING
   deploy-staging:
     runs-on: ubuntu-latest
-    needs: [quality-checks, security-scan, e2e-tests]
+    needs: [db-migrate]
     if: github.ref == 'refs/heads/main'
     environment: staging
     steps:
@@ -165,7 +216,7 @@ jobs:
   # 🏭 PRODUCTION DEPLOYMENT
   deploy-production:
     runs-on: ubuntu-latest
-    needs: [quality-checks, security-scan, e2e-tests]
+    needs: [db-migrate]
     if: github.event_name == 'release'
     environment: production
     steps:

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT="${1:-}"
+if [[ -z "${ENVIRONMENT}" ]]; then
+  echo "Usage: $0 <environment>" >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+  echo "SUPABASE_DB_URL must be defined to run migrations." >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_ACCESS_TOKEN:-}" ]]; then
+  echo "SUPABASE_ACCESS_TOKEN must be defined to run migrations." >&2
+  exit 1
+fi
+
+echo "⚙️  Applying Supabase migrations for environment: ${ENVIRONMENT}" >&2
+
+supabase db push --db-url "${SUPABASE_DB_URL}"

--- a/scripts/db_rollback.sh
+++ b/scripts/db_rollback.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT="${1:-}"
+if [[ -z "${ENVIRONMENT}" ]]; then
+  echo "Usage: $0 <environment>" >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+  echo "SUPABASE_DB_URL must be defined to roll back migrations." >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_ACCESS_TOKEN:-}" ]]; then
+  echo "SUPABASE_ACCESS_TOKEN must be defined to roll back migrations." >&2
+  exit 1
+fi
+
+echo "↩️  Rolling back last Supabase migration for environment: ${ENVIRONMENT}" >&2
+
+supabase migration down 1 --db-url "${SUPABASE_DB_URL}"


### PR DESCRIPTION
## Summary
- add a dedicated `db-migrate` job that runs Supabase CLI migrations before staging and production deploys
- wire staging and production deploy jobs to depend on migrations and trigger automated rollbacks on failure
- provide reusable shell scripts for running and rolling back Supabase migrations in CI

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2cdbe2fc0832d96100e0efd1ab216