### PR TITLE
Add Supabase migration automation with rollback support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,6 +106,32 @@ jobs:
           name: playwright-report
           path: playwright-report/
 
+  # 🧪 DATABASE MIGRATION VERIFICATION
+  db-migration-verification:
+    runs-on: ubuntu-latest
+    needs: quality-checks
+    if: github.ref == 'refs/heads/main' && secrets.TEST_SUPABASE_DB_URL != ''
+    steps:
+      - name: 🛒 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🛠 Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: 📦 Apply migrations on test database
+        id: test_db_migrate
+        env:
+          SUPABASE_DB_URL: ${{ secrets.TEST_SUPABASE_DB_URL }}
+        run: ./scripts/db_migrate.sh test
+
+      - name: 🔁 Rollback migrations on test database
+        if: always()
+        env:
+          SUPABASE_DB_URL: ${{ secrets.TEST_SUPABASE_DB_URL }}
+        run: ./scripts/db_rollback.sh test
+
   # 🏗️ BUILD & DEPLOY STAGING
   deploy-staging:
     runs-on: ubuntu-latest
@@ -130,6 +156,23 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+
+      - name: 🛠 Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: 🗄️ Run database migrations (staging)
+        id: staging_db_migrate
+        env:
+          SUPABASE_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: ./scripts/db_migrate.sh staging
+
+      - name: 🔁 Rollback database on failure (staging)
+        if: failure() && steps.staging_db_migrate.outcome == 'failure'
+        env:
+          SUPABASE_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: ./scripts/db_rollback.sh staging
 
       - name: 🐳 Build Docker image
         run: |
@@ -186,6 +229,23 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
+
+      - name: 🛠 Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: 🗄️ Run database migrations (production)
+        id: production_db_migrate
+        env:
+          SUPABASE_DB_URL: ${{ secrets.PROD_SUPABASE_DB_URL }}
+        run: ./scripts/db_migrate.sh production
+
+      - name: 🔁 Rollback database on failure (production)
+        if: failure() && steps.production_db_migrate.outcome == 'failure'
+        env:
+          SUPABASE_DB_URL: ${{ secrets.PROD_SUPABASE_DB_URL }}
+        run: ./scripts/db_rollback.sh production
 
       - name: 🐳 Build production Docker image
         run: |

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI is required but not installed." >&2
+  exit 1
+fi
+
+ENVIRONMENT_NAME=${1:-}
+if [[ -z "${ENVIRONMENT_NAME}" ]]; then
+  echo "Usage: $0 <environment>" >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+  echo "SUPABASE_DB_URL environment variable is required." >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+echo "🚀 Applying Supabase migrations to '${ENVIRONMENT_NAME}'..."
+supabase db push --db-url "${SUPABASE_DB_URL}"
+echo "✅ Migrations applied successfully on '${ENVIRONMENT_NAME}'."

--- a/scripts/db_rollback.sh
+++ b/scripts/db_rollback.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI is required but not installed." >&2
+  exit 1
+fi
+
+ENVIRONMENT_NAME=${1:-}
+if [[ -z "${ENVIRONMENT_NAME}" ]]; then
+  echo "Usage: $0 <environment> [steps]" >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+  echo "SUPABASE_DB_URL environment variable is required." >&2
+  exit 1
+fi
+
+ROLLBACK_LAST=${ROLLBACK_LAST:-${2:-1}}
+if ! [[ "${ROLLBACK_LAST}" =~ ^[0-9]+$ ]]; then
+  echo "ROLLBACK_LAST must be a positive integer (received: ${ROLLBACK_LAST})." >&2
+  exit 1
+fi
+
+if (( ROLLBACK_LAST < 1 )); then
+  echo "ROLLBACK_LAST must be at least 1." >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+echo "⚠️ Reverting the last ${ROLLBACK_LAST} migration(s) on '${ENVIRONMENT_NAME}'..."
+YES=1 supabase migration down --db-url "${SUPABASE_DB_URL}" --last "${ROLLBACK_LAST}"
+echo "✅ Rollback completed on '${ENVIRONMENT_NAME}'."


### PR DESCRIPTION
## Summary
- add Supabase migration verification job that applies and rolls back migrations against the test database
- run Supabase CLI migrations during staging and production deploys with automatic rollback on failure
- add reusable scripts to apply and revert Supabase migrations in CI

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d2cdbee484832d9ec09225830939d7