### PR TITLE
Add post-deploy smoke checks for staging and production

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -162,6 +162,88 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  smoke-tests-staging:
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    if: needs.deploy-staging.result == 'success'
+    environment: staging
+    steps:
+      - name: 🔍 Verify staging endpoints are reachable
+        env:
+          BASE_URL: ${{ secrets.STAGING_APP_URL }}
+        run: |
+          if [ -z "${BASE_URL}" ]; then
+            echo "❌ STAGING_APP_URL secret is not configured"
+            exit 1
+          fi
+
+          BASE_URL=${BASE_URL%/}
+          declare -a paths=("/" "/items" "/item/001")
+
+          for path in "${paths[@]}"; do
+            url="${BASE_URL}${path}"
+            echo "🔄 Checking ${url}"
+            status=$(curl -sSL -o /tmp/response --write-out "%{http_code}" "${url}")
+            if [ "${status}" != "200" ]; then
+              echo "❌ ${url} returned HTTP ${status}"
+              exit 1
+            fi
+          done
+
+          echo "✅ All staging endpoints responded with HTTP 200"
+
+      - name: 🛒 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: 📥 Install dependencies
+        run: npm ci
+
+      - name: 🎭 Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: 🚨 Run staging smoke tests
+        env:
+          SMOKE_BASE_URL: ${{ secrets.STAGING_APP_URL }}
+        run: npx playwright test --config tests/smoke/playwright.smoke.config.ts
+
+      - name: 📸 Upload smoke artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: staging-smoke-report
+          path: |
+            playwright-smoke-report
+            playwright-report
+
+      - name: 🔁 Trigger automatic staging rollback
+        if: failure()
+        env:
+          ROLLBACK_WEBHOOK: ${{ secrets.STAGING_ROLLBACK_WEBHOOK }}
+        run: |
+          echo "⚠️ Smoke tests failed on staging. Initiating rollback sequence."
+          if [ -n "${ROLLBACK_WEBHOOK}" ]; then
+            curl -sSL -X POST -H 'Content-Type: application/json' \
+              -d '{"environment":"staging","status":"rollback","sha":"'"${GITHUB_SHA}"'"}' \
+              "${ROLLBACK_WEBHOOK}" || true
+          else
+            echo "ℹ️ No STAGING_ROLLBACK_WEBHOOK configured. Please handle rollback manually."
+          fi
+
+      - name: 📣 Alert smoke failure on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          status: failure
+          text: "🚨 Smoke tests failed on staging after deploy for commit ${{ github.sha }}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   # 🏭 PRODUCTION DEPLOYMENT
   deploy-production:
     runs-on: ubuntu-latest
@@ -215,6 +297,74 @@ jobs:
         with:
           status: ${{ job.status }}
           text: "🏭 Production deployment ${{ job.status }} for release ${{ github.ref_name }}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  smoke-tests-production:
+    runs-on: ubuntu-latest
+    needs: deploy-production
+    if: github.event_name == 'release' && needs.deploy-production.result == 'success'
+    environment: production
+    steps:
+      - name: 🔍 Verify production endpoints are reachable
+        env:
+          BASE_URL: ${{ secrets.PROD_APP_URL }}
+        run: |
+          if [ -z "${BASE_URL}" ]; then
+            echo "❌ PROD_APP_URL secret is not configured"
+            exit 1
+          fi
+
+          BASE_URL=${BASE_URL%/}
+          declare -a paths=("/" "/items" "/item/001")
+
+          for path in "${paths[@]}"; do
+            url="${BASE_URL}${path}"
+            echo "🔄 Checking ${url}"
+            status=$(curl -sSL -o /tmp/response --write-out "%{http_code}" "${url}")
+            if [ "${status}" != "200" ]; then
+              echo "❌ ${url} returned HTTP ${status}"
+              exit 1
+            fi
+          done
+
+          echo "✅ All production endpoints responded with HTTP 200"
+
+      - name: 🛒 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: 📥 Install dependencies
+        run: npm ci
+
+      - name: 🎭 Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: 🚨 Run production smoke tests
+        env:
+          SMOKE_BASE_URL: ${{ secrets.PROD_APP_URL }}
+        run: npx playwright test --config tests/smoke/playwright.smoke.config.ts
+
+      - name: 📸 Upload production smoke artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: production-smoke-report
+          path: |
+            playwright-smoke-report
+            playwright-report
+
+      - name: 📣 Alert production smoke failure on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          status: failure
+          text: "🚨 Smoke tests failed on production after release ${{ github.ref_name }}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/tests/smoke/playwright.smoke.config.ts
+++ b/tests/smoke/playwright.smoke.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.SMOKE_BASE_URL?.replace(/\/$/, '') || 'http://127.0.0.1:4173';
+
+export default defineConfig({
+  testDir: './tests/smoke',
+  retries: process.env.CI ? 1 : 0,
+  fullyParallel: false,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-smoke-report', open: 'never' }],
+  ],
+  timeout: 45000,
+  expect: {
+    timeout: 10000,
+  },
+  use: {
+    baseURL,
+    actionTimeout: 10000,
+    navigationTimeout: 20000,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+    extraHTTPHeaders: {
+      'Accept-Language': 'fr-FR,fr;q=0.9',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, Page } from '@playwright/test';
+
+const smokeScenarios: Array<{
+  name: string;
+  path: string;
+  verify: (page: Page) => Promise<void>;
+}> = [
+  {
+    name: 'homepage',
+    path: '/',
+    verify: async (page: Page) => {
+      await expect(page.getByRole('heading', { name: /MED-MNG/i })).toBeVisible();
+      await expect(page.locator("text=L'IA au Service de l'Excellence Médicale")).toBeVisible();
+    },
+  },
+  {
+    name: 'items catalog',
+    path: '/items',
+    verify: async (page: Page) => {
+      await expect(page.getByRole('heading', { name: /Items EDN MED MNG/i })).toBeVisible();
+      await expect(page.getByText('Progression Globale EDN', { exact: false })).toBeVisible();
+    },
+  },
+  {
+    name: 'item detail IC-001',
+    path: '/item/001',
+    verify: async (page: Page) => {
+      await expect(page.getByRole('link', { name: /Retour aux items EDN/i })).toBeVisible();
+      await expect(page.getByText('Mode Immersif', { exact: false })).toBeVisible();
+    },
+  },
+];
+
+test.describe('🚨 Post-deployment smoke', () => {
+  for (const scenario of smokeScenarios) {
+    test(`should keep ${scenario.name} available (${scenario.path})`, async ({ page }) => {
+      const response = await page.goto(scenario.path, {
+        waitUntil: 'networkidle',
+      });
+
+      expect(response, `Aucune réponse pour ${scenario.path}`).toBeTruthy();
+      expect(response?.status(), `HTTP inattendu sur ${scenario.path}`).toBe(200);
+
+      await expect(page.locator('#app-root')).toBeVisible();
+      await scenario.verify(page);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add staging smoke-test job that validates critical endpoints, runs Playwright checks, and triggers rollback plus Slack alerting on failure
- add production smoke-test job mirroring the staging checks for releases
- introduce a dedicated Playwright smoke configuration and spec covering `/`, `/items`, and `/item/001`

## Testing
- npm run lint *(fails: repository already contains numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cdcd55d4832d83077a6097a20ebc