### PR TITLE
Add consolidated security scan workflow

### DIFF
--- a/.github/scripts/security-report.mjs
+++ b/.github/scripts/security-report.mjs
@@ -1,0 +1,183 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const key = argv[i];
+    if (!key.startsWith('--')) {
+      continue;
+    }
+    const normalizedKey = key.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[normalizedKey] = true;
+    } else {
+      args[normalizedKey] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function ensurePath(path) {
+  if (!path) {
+    throw new Error('Expected path to be provided but received empty string');
+  }
+  return path;
+}
+
+function parseNpmAudit(path) {
+  const counts = { low: 0, moderate: 0, high: 0, critical: 0 };
+  if (!path) {
+    return { counts, metadata: {} };
+  }
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  const metaCounts = raw?.metadata?.vulnerabilities ?? {};
+  for (const key of Object.keys(counts)) {
+    counts[key] = Number(metaCounts[key] ?? 0);
+  }
+  return { counts, metadata: raw?.metadata ?? {} };
+}
+
+function normalizeSeverity(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+  const lower = text.toLowerCase();
+  if (lower.includes('critical')) {
+    return 'critical';
+  }
+  if (lower.includes('high')) {
+    return 'high';
+  }
+  if (lower.includes('medium') || lower.includes('moderate')) {
+    return 'moderate';
+  }
+  if (lower.includes('low')) {
+    return 'low';
+  }
+  const numeric = Number.parseFloat(lower);
+  if (!Number.isNaN(numeric)) {
+    if (numeric >= 9) {
+      return 'critical';
+    }
+    if (numeric >= 7) {
+      return 'high';
+    }
+    if (numeric >= 4) {
+      return 'moderate';
+    }
+    if (numeric > 0) {
+      return 'low';
+    }
+  }
+  return null;
+}
+
+function parseTrivySarif(path) {
+  const counts = { low: 0, moderate: 0, high: 0, critical: 0 };
+  if (!path) {
+    return { counts, runs: [] };
+  }
+  const sarif = JSON.parse(readFileSync(path, 'utf8'));
+  const runs = Array.isArray(sarif?.runs) ? sarif.runs : [];
+  for (const run of runs) {
+    const results = Array.isArray(run?.results) ? run.results : [];
+    for (const result of results) {
+      const props = result?.properties ?? {};
+      const severity = normalizeSeverity(
+        props.severity ??
+          props.Severity ??
+          props['severity_level'] ??
+          props['SecuritySeverity'] ??
+          props['security-severity'] ??
+          props?.cvss?.severity ??
+          props?.cvss?.baseSeverity ??
+          props?.cvssV3?.baseSeverity ??
+          props?.CVSSv3?.baseSeverity ??
+          result.level
+      );
+      if (severity && severity in counts) {
+        counts[severity] += 1;
+      }
+    }
+  }
+  return { counts, runs };
+}
+
+function buildTotals(...sources) {
+  const totals = { low: 0, moderate: 0, high: 0, critical: 0 };
+  for (const source of sources) {
+    for (const key of Object.keys(totals)) {
+      totals[key] += Number(source?.counts?.[key] ?? 0);
+    }
+  }
+  return totals;
+}
+
+function createMarkdownTable(rows) {
+  const header = ['| Scanner | Critical | High | Moderate | Low |', '| --- | --- | --- | --- | --- |'];
+  const body = rows.map(({ name, counts }) =>
+    `| ${name} | ${counts.critical} | ${counts.high} | ${counts.moderate} | ${counts.low} |`
+  );
+  return header.concat(body).join('\n');
+}
+
+function mergeSarifFiles(files) {
+  const merged = { version: '2.1.0', runs: [] };
+  for (const file of files) {
+    if (!file) {
+      continue;
+    }
+    const sarif = JSON.parse(readFileSync(file, 'utf8'));
+    if (!merged.$schema && sarif.$schema) {
+      merged.$schema = sarif.$schema;
+    }
+    if (Array.isArray(sarif?.runs)) {
+      merged.runs.push(...sarif.runs);
+    }
+  }
+  return merged;
+}
+
+const args = parseArgs(process.argv);
+const npmJsonPath = args['npm-json'] ? ensurePath(args['npm-json']) : null;
+const npmSarifPath = args['npm-sarif'] ? ensurePath(args['npm-sarif']) : null;
+const trivySarifPath = args['trivy-sarif'] ? ensurePath(args['trivy-sarif']) : null;
+const summaryPath = args.summary ? ensurePath(args.summary) : null;
+const mergedSarifPath = args.merged ? ensurePath(args.merged) : null;
+
+const npmData = parseNpmAudit(npmJsonPath);
+const trivyData = parseTrivySarif(trivySarifPath);
+const totals = buildTotals(npmData, trivyData);
+const rows = [
+  { name: 'npm audit', counts: npmData.counts },
+  { name: 'Trivy (image)', counts: trivyData.counts },
+  { name: '**Totals**', counts: totals },
+];
+const markdown = createMarkdownTable(rows);
+const summary = {
+  npm: npmData,
+  trivy: trivyData,
+  totals,
+  markdown,
+  blocking: totals.high + totals.critical > 0,
+};
+
+if (summaryPath) {
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+}
+
+if (mergedSarifPath) {
+  const merged = mergeSarifFiles([npmSarifPath, trivySarifPath]);
+  writeFileSync(mergedSarifPath, JSON.stringify(merged, null, 2));
+}
+
+console.log(markdown);
+if (summary.blocking && args['fail-on-high']) {
+  throw new Error('High or critical vulnerabilities detected.');
+}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,109 @@
+name: Security Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  audit:
+    name: Consolidated security report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: |
+          npm audit --json > npm-audit.json || true
+
+      - name: Convert npm audit to SARIF
+        run: |
+          npx --yes audit2sarif --input npm-audit.json --output npm-audit.sarif
+
+      - name: Build application image
+        run: docker build -t mmg-security-scan:latest .
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@v0.16.0
+        with:
+          image-ref: mmg-security-scan:latest
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+
+      - name: Generate consolidated report
+        run: |
+          node .github/scripts/security-report.mjs \
+            --npm-json npm-audit.json \
+            --npm-sarif npm-audit.sarif \
+            --trivy-sarif trivy-results.sarif \
+            --summary security-summary.json \
+            --merged security-aggregate.sarif
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: security-aggregate.sarif
+
+      - name: Comment security summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const summaryPath = 'security-summary.json';
+            if (!fs.existsSync(summaryPath)) {
+              core.warning('security-summary.json not found');
+              return;
+            }
+            const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+            const marker = '<!-- security-summary -->';
+            const body = `${marker}\n### 🔐 Security scan summary\n\n${summary.markdown}\n\n- **Critical vulnerabilities**: ${summary.totals.critical}\n- **High vulnerabilities**: ${summary.totals.high}\n- **Moderate vulnerabilities**: ${summary.totals.moderate}\n- **Low vulnerabilities**: ${summary.totals.low}\n- **Blocking issues**: ${summary.blocking ? 'Yes' : 'No'}\n`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.body &&
+                comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Enforce high/critical vulnerability gate
+        run: |
+          node -e "const fs=require('fs'); const summary=JSON.parse(fs.readFileSync('security-summary.json','utf8')); const blocking=Number(summary.totals?.high ?? 0)+Number(summary.totals?.critical ?? 0); if (blocking > 0) { console.error(`Blocking vulnerabilities detected (high/critical): ${blocking}`); process.exit(1); } console.log('No blocking high or critical vulnerabilities detected.');"


### PR DESCRIPTION
## Summary
- add a security workflow that runs npm audit and Trivy, merges SARIF output, and uploads the consolidated report
- create a helper script to build the combined SARIF, generate a markdown summary, and surface blocking vulnerability counts via PR comments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2cdeb41b8832d8f7d4f65e7e3a1d1