### PR TITLE
Add frontend Sentry release and health build metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,10 +67,19 @@ LOG_FORMAT=json
 
 # Error Monitoring (Optional but recommended for production)
 SENTRY_DSN=https://your-sentry-dsn@o123456.ingest.sentry.io/123456
+VITE_SENTRY_DSN=https://your-sentry-dsn@o123456.ingest.sentry.io/123456
+APP_VERSION=1.0.0
+BUILD_SHA=local-dev
+BUILD_TIMESTAMP=2024-01-01T00:00:00.000Z
 
 # Alerting Webhooks
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook-url
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your-webhook-url
+ALERT_EMAIL=alerts@your-domain.com
+ALERT_FROM_EMAIL=MedMNG Alerts <alerts@your-domain.com>
+UPTIME_HEALTH_URL=https://your-domain.com/health
+UPTIME_TIMEOUT_MS=5000
+UPTIME_EXPECTED_STATUS=healthy
 
 # ===================================
 # EXTRACTION & CAS AUTHENTICATION

--- a/README-DEVOPS.md
+++ b/README-DEVOPS.md
@@ -98,6 +98,8 @@ Store them in `.env` for local use and configure the same variables as project s
 - Supabase provides logs for edge functions, database and storage (dashboard ➜ Logs).
 - The Express API logs to stdout via `supabase/functions/med-mng-api/logger.ts`.
 - Alerts can be sent to Discord or Slack when `DISCORD_WEBHOOK_URL` or `SLACK_WEBHOOK_URL` are defined. See `src/services/alertService.ts`.
+- Frontend errors are sent to Sentry when `VITE_SENTRY_DSN` is configured. The release tag is derived from `BUILD_SHA`/`APP_VERSION` to ease correlation with deployments.
+- A cron-compatible uptime probe is available via `npm run monitor:uptime` (recommended every 5 minutes). It pings `UPTIME_HEALTH_URL` and triggers Slack/email alerts through `ALERT_EMAIL` + webhooks when the check fails.
 - Database logs are stored in the `operation_logs` table via `logService.ts` and can feed a Metabase or Grafana dashboard (see `docs/dashboard-monitoring.md`).
 
 ## 7. Extraction batch / cleaning data

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
+    "monitor:uptime": "node --loader ts-node/esm scripts/uptimeMonitor.ts",
     "test:e2e:cypress": "cypress run --browser chrome --headless --config baseUrl=http://127.0.0.1:4173",
     "integrity:audit": "node --loader ts-node/esm scripts/dataIntegrityAudit.ts",
     "audit": "node scripts/run-audit.js",

--- a/scripts/uptimeMonitor.ts
+++ b/scripts/uptimeMonitor.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env ts-node
+import axios, { AxiosError } from 'axios';
+import process from 'node:process';
+import { notifyIncident } from '../src/services/alertService.ts';
+
+const healthUrl = process.env.UPTIME_HEALTH_URL || 'http://localhost:3000/health';
+const timeoutMs = Number(process.env.UPTIME_TIMEOUT_MS || '5000');
+const expectedStatus = process.env.UPTIME_EXPECTED_STATUS || 'healthy';
+
+interface HealthResponse {
+  status?: string;
+  build?: {
+    hash?: string;
+    timestamp?: string;
+  };
+}
+
+async function run(): Promise<void> {
+  const startedAt = Date.now();
+
+  try {
+    const response = await axios.get<HealthResponse>(healthUrl, {
+      timeout: timeoutMs,
+      validateStatus: () => true,
+    });
+    const duration = Date.now() - startedAt;
+
+    const bodyStatus = response.data?.status;
+    const buildHash = response.data?.build?.hash;
+
+    if (response.status !== 200 || bodyStatus !== expectedStatus || !buildHash) {
+      console.error(
+        `[uptime] ${new Date().toISOString()} • FAIL (${duration}ms) – status=${response.status}, bodyStatus=${bodyStatus}`
+      );
+
+      await notifyIncident({
+        type: 'UPTIME_CHECK_FAILED',
+        severity: 'critical',
+        message: `Health check returned ${response.status} for ${healthUrl}`,
+        details: {
+          duration,
+          expectedStatus,
+          receivedStatus: response.status,
+          bodyStatus,
+          response: response.data,
+        },
+      });
+
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(
+      `[uptime] ${new Date().toISOString()} • OK (${duration}ms) – build=${buildHash} timestamp=${response.data?.build?.timestamp}`
+    );
+  } catch (error) {
+    const duration = Date.now() - startedAt;
+    const axiosError = axios.isAxiosError(error) ? (error as AxiosError) : undefined;
+    const message = axiosError?.message || (error instanceof Error ? error.message : String(error));
+
+    console.error(`[uptime] ${new Date().toISOString()} • ERROR (${duration}ms) – ${message}`);
+
+    await notifyIncident({
+      type: 'UPTIME_CHECK_FAILED',
+      severity: 'critical',
+      message: `Health check failed for ${healthUrl}`,
+      details: {
+        duration,
+        code: axiosError?.code,
+        status: axiosError?.response?.status,
+        data: axiosError?.response?.data,
+        message,
+      },
+    });
+
+    process.exitCode = 1;
+  }
+}
+
+void run();

--- a/src/components/monitoring/SentryErrorMonitor.tsx
+++ b/src/components/monitoring/SentryErrorMonitor.tsx
@@ -184,7 +184,7 @@ export const SentryErrorMonitor = () => {
             </div>
             {!isConnected && (
               <p className="text-sm text-red-600 mt-1">
-                Configurez votre DSN Sentry dans src/utils/sentry.ts pour activer le monitoring
+                Définissez la variable d'environnement <code>VITE_SENTRY_DSN</code> pour activer le monitoring
               </p>
             )}
           </Card>
@@ -254,7 +254,7 @@ export const SentryErrorMonitor = () => {
               </CardTitle>
               <div className="text-sm text-blue-700 space-y-1">
                 <p>• Erreurs simulées toutes les 30 secondes</p>
-                <p>• DSN Sentry à configurer dans src/utils/sentry.ts</p>
+                <p>• DSN Sentry à configurer via <code>VITE_SENTRY_DSN</code></p>
                 <p>• Les erreurs sont automatiquement envoyées vers Sentry si configuré</p>
               </div>
             </Card>

--- a/src/controllers/healthController.ts
+++ b/src/controllers/healthController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
-import { getHealthMessage } from '../services/healthService';
+import { getHealthStatus } from '../services/healthService';
 
 export const healthCheck = (_req: Request, res: Response) => {
-  res.json({ status: 'ok', message: getHealthMessage() });
+  res.json(getHealthStatus());
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from './middleware/security';
 import { validateSecurityConfig, getSecurityConfig } from './config/security';
 import { createCSPMiddleware } from './utils/security/cspHelper';
+import { getBuildInfo, getHealthStatus } from './services/healthService';
 
 const app = express();
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -56,11 +57,13 @@ app.use(securityHeadersMiddleware);
 
 // Routes principales
 app.get('/', (_req, res) => {
-  logService.info('Health check endpoint accessed');
+  logService.info('Root endpoint accessed');
+  const build = getBuildInfo();
   res.json({
     status: 'ok',
     message: 'Medical Training API is running',
-    version: '1.0.0',
+    version: build.version,
+    build,
     timestamp: new Date().toISOString()
   });
 });
@@ -68,12 +71,7 @@ app.get('/', (_req, res) => {
 // Route de santé pour les monitoring
 app.get('/health', (_req, res) => {
   logService.debug('Health check endpoint accessed');
-  res.json({
-    status: 'healthy',
-    uptime: process.uptime(),
-    memory: process.memoryUsage(),
-    timestamp: new Date().toISOString()
-  });
+  res.json(getHealthStatus());
 });
 
 // Middleware de gestion des erreurs 404

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,5 +2,8 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { initSentry } from './utils/monitoring/sentry.ts';
+
+initSentry();
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/services/alertService.ts
+++ b/src/services/alertService.ts
@@ -6,7 +6,8 @@ export type IncidentType =
   | 'BACKEND_ERROR'
   | 'QUOTA_EXCEEDED'
   | 'SUPABASE_DOWN'
-  | 'ERROR_PATTERN_DETECTED';
+  | 'ERROR_PATTERN_DETECTED'
+  | 'UPTIME_CHECK_FAILED';
 
 export interface Incident {
   type: IncidentType;
@@ -17,9 +18,13 @@ export interface Incident {
 
 const discordWebhook = process.env.DISCORD_WEBHOOK_URL;
 const slackWebhook = process.env.SLACK_WEBHOOK_URL;
+const resendApiKey = process.env.RESEND_API_KEY;
+const alertEmail = process.env.ALERT_EMAIL;
+const alertFromEmail = process.env.ALERT_FROM_EMAIL || 'MedMNG Alerts <alerts@medmng.app>';
 
 export async function notifyIncident(incident: Incident): Promise<void> {
   const tasks: Promise<unknown>[] = [];
+  const severity = incident.severity ?? 'warning';
   const text = `[${incident.type}] ${incident.message}`;
 
   if (discordWebhook) {
@@ -36,6 +41,45 @@ export async function notifyIncident(incident: Incident): Promise<void> {
         .post(slackWebhook, { text, incident })
         .catch((err) => console.error('Slack alert failed', err))
     );
+  }
+
+  if (resendApiKey && alertEmail) {
+    const recipients = alertEmail
+      .split(',')
+      .map((email) => email.trim())
+      .filter(Boolean);
+
+    if (recipients.length > 0) {
+      const htmlBody = `
+        <h2>Incident ${incident.type}</h2>
+        <p><strong>Message :</strong> ${incident.message}</p>
+        <p><strong>Gravité :</strong> ${severity}</p>
+        <p><strong>Horodatage :</strong> ${new Date().toISOString()}</p>
+        <pre style="background:#f4f4f5;padding:12px;border-radius:6px;white-space:pre-wrap;">${
+          incident.details ? JSON.stringify(incident.details, null, 2) : 'Aucun détail fourni'
+        }</pre>
+      `;
+
+      tasks.push(
+        axios
+          .post(
+            'https://api.resend.com/emails',
+            {
+              from: alertFromEmail,
+              to: recipients,
+              subject: `[${severity}] ${incident.type}`,
+              html: htmlBody,
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${resendApiKey}`,
+                'Content-Type': 'application/json',
+              },
+            }
+          )
+          .catch((err) => console.error('Email alert failed', err))
+      );
+    }
   }
 
   if (tasks.length) {

--- a/src/services/healthService.ts
+++ b/src/services/healthService.ts
@@ -1,1 +1,46 @@
-export const getHealthMessage = () => 'Med-MNG API running';
+export interface BuildInfo {
+  hash: string;
+  timestamp: string;
+  version: string;
+  environment: string;
+}
+
+export interface HealthStatus {
+  status: 'healthy';
+  message: string;
+  uptime: number;
+  memory: NodeJS.MemoryUsage;
+  timestamp: string;
+  build: BuildInfo;
+}
+
+const BUILD_INFO: BuildInfo = {
+  hash:
+    process.env.BUILD_SHA ||
+    process.env.BUILD_HASH ||
+    process.env.GITHUB_SHA ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.SUPABASE_REF ||
+    'local-dev',
+  timestamp:
+    process.env.BUILD_TIMESTAMP ||
+    process.env.DEPLOYED_AT ||
+    new Date().toISOString(),
+  version: process.env.APP_VERSION || '1.0.0',
+  environment: process.env.NODE_ENV || 'development',
+};
+
+const HEALTH_MESSAGE = 'Med-MNG API running';
+
+export const getBuildInfo = (): BuildInfo => ({ ...BUILD_INFO });
+
+export const getHealthStatus = (): HealthStatus => ({
+  status: 'healthy',
+  message: HEALTH_MESSAGE,
+  uptime: process.uptime(),
+  memory: process.memoryUsage(),
+  timestamp: new Date().toISOString(),
+  build: getBuildInfo(),
+});
+
+export const getHealthMessage = () => HEALTH_MESSAGE;

--- a/src/utils/monitoring/sentry.ts
+++ b/src/utils/monitoring/sentry.ts
@@ -1,50 +1,92 @@
 import * as Sentry from '@sentry/react';
 
+let isInitialized = false;
+
+const resolveRelease = () => {
+  const releaseCandidates = [
+    import.meta.env.VITE_SENTRY_RELEASE,
+    import.meta.env.VITE_BUILD_SHA,
+    import.meta.env.VITE_BUILD_HASH,
+    import.meta.env.VITE_COMMIT_SHA,
+    import.meta.env.VITE_GIT_COMMIT_SHA,
+  ].filter((value): value is string => Boolean(value));
+
+  return releaseCandidates[0] ?? 'local-dev';
+};
+
+const resolveEnvironment = () =>
+  import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE || 'development';
+
+const resolveDsn = () =>
+  import.meta.env.VITE_SENTRY_DSN || (import.meta as unknown as { env?: Record<string, string> }).env?.SENTRY_DSN;
+
 // Configuration Sentry pour monitoring des erreurs frontend
 export const initSentry = () => {
+  if (isInitialized) {
+    return;
+  }
+
+  const dsn = resolveDsn();
+
+  if (!dsn) {
+    if (import.meta.env.DEV) {
+      console.info('[Sentry] DSN non fourni, monitoring désactivé.');
+    }
+    return;
+  }
+
+  const release = resolveRelease();
+  const environment = resolveEnvironment();
+  const isProduction = environment === 'production';
+
   Sentry.init({
-    dsn: 'https://your-sentry-dsn@sentry.io/project-id', // À remplacer par votre DSN Sentry
-    environment: import.meta.env.MODE || 'development',
+    dsn,
+    release,
+    environment,
     integrations: [
       Sentry.browserTracingIntegration(),
     ],
-    
+
     // Taux d'échantillonnage des erreurs (100% en dev, 50% en prod)
-    sampleRate: import.meta.env.MODE === 'production' ? 0.5 : 1.0,
-    
+    sampleRate: isProduction ? 0.5 : 1.0,
+
     // Taux d'échantillonnage des performances (10% en prod pour éviter les quotas)
-    tracesSampleRate: import.meta.env.MODE === 'production' ? 0.1 : 1.0,
-    
+    tracesSampleRate: isProduction ? 0.1 : 1.0,
+
     // Configuration avancée
     beforeSend(event, hint) {
       // Filtrer les erreurs non critiques
       if (event.exception) {
         const error = hint.originalException as Error;
-        
+
         // Ignorer les erreurs réseau temporaires
-        if (error?.message?.includes('Network Error') || 
+        if (error?.message?.includes('Network Error') ||
             error?.message?.includes('fetch')) {
           return null;
         }
-        
+
         // Ignorer les erreurs de quota API (déjà gérées côté UX)
-        if (error?.message?.includes('quota') || 
+        if (error?.message?.includes('quota') ||
             error?.message?.includes('rate limit')) {
           return null;
         }
       }
-      
+
       return event;
     },
-    
+
     // Tags par défaut pour faciliter le debug
     initialScope: {
       tags: {
         component: 'frontend',
-        version: '1.0.0'
+        'build.hash': release,
       },
     },
   });
+
+  Sentry.setTag('build.hash', release);
+
+  isInitialized = true;
 };
 
 // Hook pour capturer les erreurs de composants React

--- a/test/api/security.test.ts
+++ b/test/api/security.test.ts
@@ -142,6 +142,11 @@ describe('API Security Tests', () => {
       expect(response.body).toHaveProperty('uptime');
       expect(response.body).toHaveProperty('memory');
       expect(response.body).toHaveProperty('timestamp');
+      expect(response.body).toHaveProperty('build');
+      expect(response.body.build).toMatchObject({
+        hash: expect.any(String),
+        timestamp: expect.any(String),
+      });
     });
 
     it('should provide main endpoint with API info', async () => {
@@ -154,6 +159,12 @@ describe('API Security Tests', () => {
       expect(response.body.message).toBe('Medical Training API is running');
       expect(response.body).toHaveProperty('version');
       expect(response.body.version).toBe('1.0.0');
+      expect(response.body).toHaveProperty('build');
+      expect(response.body.build).toMatchObject({
+        hash: expect.any(String),
+        timestamp: expect.any(String),
+        version: '1.0.0',
+      });
     });
   });
 

--- a/test/healthRoute.test.ts
+++ b/test/healthRoute.test.ts
@@ -10,5 +10,10 @@ app.use(errorHandler);
 test('GET /health returns ok', async () => {
   const res = await request(app).get('/health');
   expect(res.status).toBe(200);
-  expect(res.body.status).toBe('ok');
+  expect(res.body.status).toBe('healthy');
+  expect(res.body).toHaveProperty('build');
+  expect(res.body.build).toMatchObject({
+    hash: expect.any(String),
+    timestamp: expect.any(String),
+  });
 });

--- a/test/healthService.test.ts
+++ b/test/healthService.test.ts
@@ -1,5 +1,21 @@
-import { getHealthMessage } from '../src/services/healthService';
+import { getBuildInfo, getHealthMessage, getHealthStatus } from '../src/services/healthService';
 
 test('returns default health message', () => {
   expect(getHealthMessage()).toBe('Med-MNG API running');
+});
+
+test('health status exposes build metadata', () => {
+  const status = getHealthStatus();
+  expect(status.build.hash).toBeTruthy();
+  expect(status.build.timestamp).toBeTruthy();
+  expect(status.build.version).toBeTruthy();
+});
+
+test('build info helper mirrors health status build data', () => {
+  const buildInfo = getBuildInfo();
+  expect(buildInfo).toMatchObject({
+    hash: expect.any(String),
+    timestamp: expect.any(String),
+    version: expect.any(String),
+  });
 });


### PR DESCRIPTION
## Summary
- initialise the React bundle with Sentry using environment-provided DSN, release tagging and updated monitoring copy
- expose build metadata on the Express health endpoints and tighten accompanying unit coverage
- add a cron-ready uptime probe plus email alerting support and document the required environment variables

## Testing
- npm test *(fails: suite expects external services such as Supabase rate limiting and long-running fixtures)*
- npx vitest run test/healthService.test.ts test/healthRoute.test.ts test/api/security.test.ts *(fails: rate limit tests depend on Supabase store network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cdfc9124832da2adefc3b8ad0231