### PR TITLE
feat: add ECOS PDF export with QR code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "next-themes": "^0.3.0",
         "playwright-lighthouse": "^4.0.0",
         "puppeteer": "^24.11.2",
+        "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -6802,6 +6803,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -8275,6 +8285,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -8403,6 +8422,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -12054,6 +12079,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -12161,7 +12195,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12333,6 +12366,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/polished": {
@@ -12698,6 +12740,182 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -13178,6 +13396,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -13529,6 +13753,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -15312,6 +15542,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "next-themes": "^0.3.0",
     "playwright-lighthouse": "^4.0.0",
     "puppeteer": "^24.11.2",
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src/components/ecos/EcosHeader.tsx
+++ b/src/components/ecos/EcosHeader.tsx
@@ -1,19 +1,29 @@
 
 import { Link } from 'react-router-dom';
-import { Stethoscope, ArrowLeft, Clock } from 'lucide-react';
+import { Stethoscope, ArrowLeft, Clock, FileDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 interface EcosHeaderProps {
   timeLeft: number;
   formatTime: (seconds: number) => string;
   scenarioId: string;
   specialty: string;
+  onExportPdf?: () => void;
+  isExporting?: boolean;
 }
 
-export const EcosHeader = ({ timeLeft, formatTime, scenarioId, specialty }: EcosHeaderProps) => {
+export const EcosHeader = ({
+  timeLeft,
+  formatTime,
+  scenarioId,
+  specialty,
+  onExportPdf,
+  isExporting,
+}: EcosHeaderProps) => {
   return (
     <div className="bg-black/20 backdrop-blur-sm border-b border-white/10">
       <div className="container mx-auto px-4 py-4">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-4">
           <Link to="/ecos" className="flex items-center gap-3 text-white hover:text-emerald-300 transition-colors">
             <ArrowLeft className="h-5 w-5" />
             <Stethoscope className="h-6 w-6" />
@@ -27,6 +37,19 @@ export const EcosHeader = ({ timeLeft, formatTime, scenarioId, specialty }: Ecos
             <div className="text-emerald-300">
               {scenarioId} • {specialty}
             </div>
+            {onExportPdf ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={onExportPdf}
+                disabled={isExporting}
+                className="print:hidden gap-2"
+              >
+                <FileDown className="h-4 w-4" aria-hidden />
+                {isExporting ? 'Préparation…' : 'Exporter PDF'}
+              </Button>
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/data/ecosData.ts
+++ b/src/data/ecosData.ts
@@ -3,6 +3,7 @@ import { MessageCircle, HandIcon, FileText } from 'lucide-react';
 
 export const scenarioData = {
   id: 'SD003',
+  itemSlug: 'douleur-thoracique-sd003',
   title: 'Douleur thoracique',
   specialty: 'Cardiologie',
   duration: 15,

--- a/src/features/export/components/EcosPdfTemplate.tsx
+++ b/src/features/export/components/EcosPdfTemplate.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import {
+  EcosPdfState,
+  EcosPrintableScenario,
+} from '../hooks/useEcosPdfExport';
+
+interface EcosPdfTemplateProps {
+  scenario: EcosPrintableScenario;
+  printState: EcosPdfState | null;
+  itemUrl: string;
+}
+
+const formatDate = (date: Date) => {
+  try {
+    return new Intl.DateTimeFormat('fr-FR', {
+      dateStyle: 'long',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return date.toLocaleString('fr-FR');
+  }
+};
+
+export const EcosPdfTemplate: React.FC<EcosPdfTemplateProps> = ({
+  scenario,
+  printState,
+  itemUrl,
+}) => {
+  if (!printState) {
+    return null;
+  }
+
+  return (
+    <div className="ecos-print-root" aria-hidden>
+      <header className="ecos-print-header">
+        <div>
+          <p className="ecos-print-meta" aria-label="Identifiants ECOS">
+            Simulation ECOS • {scenario.id}
+          </p>
+          <h1 className="ecos-print-title">{scenario.title}</h1>
+          <p className="ecos-print-subtitle">{scenario.pitch}</p>
+          <p className="ecos-print-meta">
+            Spécialité : {scenario.specialty} • Durée estimée : {scenario.duration} minutes
+          </p>
+          <p className="ecos-print-meta">
+            Patient : {scenario.patient.name} ({scenario.patient.age} ans, {scenario.patient.sex})
+          </p>
+          <p className="ecos-print-meta">{scenario.patient.background}</p>
+          <p className="ecos-print-meta">Exporté le {formatDate(printState.generatedAt)}</p>
+        </div>
+        <div className="ecos-print-qr">
+          <img src={printState.qrCodeDataUrl} alt="QR code vers l'item EDN associé" />
+          <p className="ecos-print-meta">Scanner pour ouvrir l'item associé</p>
+          <p className="ecos-print-meta" style={{ wordBreak: 'break-all', textAlign: 'center' }}>
+            {itemUrl}
+          </p>
+        </div>
+      </header>
+
+      <section className="ecos-print-section" aria-labelledby="ecos-patient-profile">
+        <h2 id="ecos-patient-profile">Profil patient</h2>
+        <p className="ecos-print-meta">
+          {scenario.patient.name} • {scenario.patient.age} ans • {scenario.patient.sex}
+        </p>
+        <p className="ecos-print-meta">{scenario.patient.background}</p>
+      </section>
+
+      {scenario.steps.map((step, index) => (
+        <section
+          key={`${step.title}-${index}`}
+          className="ecos-print-section"
+          aria-labelledby={`ecos-step-${index}`}
+        >
+          <h2 id={`ecos-step-${index}`}>
+            {index + 1}. {step.title}
+          </h2>
+          {step.subtitle ? <p className="ecos-print-meta">{step.subtitle}</p> : null}
+
+          {step.questions?.length ? (
+            <div>
+              <h3 className="ecos-print-meta" style={{ fontWeight: 600, marginTop: '2mm' }}>
+                Questions clés
+              </h3>
+              <ul>
+                {step.questions.map((question, questionIndex) => (
+                  <li key={`question-${index}-${questionIndex}`}>{question}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {step.actions?.length ? (
+            <div>
+              <h3 className="ecos-print-meta" style={{ fontWeight: 600, marginTop: '2mm' }}>
+                Actions à réaliser
+              </h3>
+              <ul>
+                {step.actions.map((action, actionIndex) => (
+                  <li key={`action-${index}-${actionIndex}`}>{action}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {step.elements?.length ? (
+            <div>
+              <h3 className="ecos-print-meta" style={{ fontWeight: 600, marginTop: '2mm' }}>
+                Points de synthèse
+              </h3>
+              <ul>
+                {step.elements.map((element, elementIndex) => (
+                  <li key={`element-${index}-${elementIndex}`}>{element}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </section>
+      ))}
+    </div>
+  );
+};

--- a/src/features/export/hooks/useEcosPdfExport.ts
+++ b/src/features/export/hooks/useEcosPdfExport.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from 'react';
+import QRCode from 'qrcode';
+
+export interface EcosScenarioStep {
+  title: string;
+  subtitle?: string;
+  questions?: string[];
+  actions?: string[];
+  elements?: string[];
+}
+
+export interface EcosPrintableScenario {
+  id: string;
+  itemSlug?: string;
+  title: string;
+  specialty: string;
+  duration: number;
+  pitch: string;
+  patient: {
+    name: string;
+    age: number;
+    sex: string;
+    background: string;
+  };
+  steps: EcosScenarioStep[];
+}
+
+interface UseEcosPdfExportParams {
+  scenario: EcosPrintableScenario;
+  itemUrl: string;
+}
+
+export interface EcosPdfState {
+  qrCodeDataUrl: string;
+  generatedAt: Date;
+}
+
+export const useEcosPdfExport = ({ scenario, itemUrl }: UseEcosPdfExportParams) => {
+  const [state, setState] = useState<EcosPdfState | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const cleanup = useCallback(() => {
+    if (typeof document !== 'undefined') {
+      document.body.classList.remove('ecos-printing');
+    }
+    setState(null);
+    setIsGenerating(false);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleAfterPrint = () => {
+      cleanup();
+    };
+
+    window.addEventListener('afterprint', handleAfterPrint);
+    return () => {
+      window.removeEventListener('afterprint', handleAfterPrint);
+      cleanup();
+    };
+  }, [cleanup]);
+
+  useEffect(() => {
+    if (!state || !isGenerating) {
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      cleanup();
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      try {
+        window.print();
+      } catch (error) {
+        console.error('ECOS PDF export - print failed', error);
+        cleanup();
+      }
+    }, 150);
+
+    return () => window.clearTimeout(timer);
+  }, [cleanup, isGenerating, state]);
+
+  const exportPdf = useCallback(async () => {
+    if (isGenerating) {
+      return;
+    }
+
+    setIsGenerating(true);
+
+    try {
+      const qrCodeDataUrl = await QRCode.toDataURL(itemUrl, {
+        margin: 0,
+        scale: 8,
+        width: 512,
+        color: {
+          dark: '#0f172a',
+          light: '#ffffff',
+        },
+      });
+
+      if (typeof document !== 'undefined') {
+        document.body.classList.add('ecos-printing');
+      }
+      setState({
+        qrCodeDataUrl,
+        generatedAt: new Date(),
+      });
+    } catch (error) {
+      console.error('ECOS PDF export failed', error);
+      cleanup();
+    }
+  }, [cleanup, isGenerating, itemUrl]);
+
+  return {
+    exportPdf,
+    isGenerating,
+    printState: state,
+    scenario,
+    itemUrl,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,5 +2,6 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './styles/print.css';
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/EcosScenario.tsx
+++ b/src/pages/EcosScenario.tsx
@@ -1,7 +1,7 @@
 
 import { ConsistentBackground } from '@/components/layout/ConsistentBackground';
 import { PageHeader } from '@/components/layout/PageHeader';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { EcosHeader } from '@/components/ecos/EcosHeader';
 import { PatientCard } from '@/components/ecos/PatientCard';
@@ -10,15 +10,56 @@ import { StepContent } from '@/components/ecos/StepContent';
 import { QuizSection } from '@/components/ecos/QuizSection';
 import { useEcosTimer } from '@/hooks/useEcosTimer';
 import { scenarioData, quizQuestions } from '@/data/ecosData';
+import { useEcosPdfExport, EcosPrintableScenario } from '@/features/export/hooks/useEcosPdfExport';
+import { EcosPdfTemplate } from '@/features/export/components/EcosPdfTemplate';
 
 const EcosScenario = () => {
-  const { slug } = useParams();
+  const { scenarioId: scenarioParam } = useParams<{ scenarioId: string }>();
   const [currentStep, setCurrentStep] = useState(0);
   const [responses, setResponses] = useState<{[key: string]: string}>({});
   const [showQuiz, setShowQuiz] = useState(false);
   const [quizAnswers, setQuizAnswers] = useState<{[key: number]: string}>({});
-  
+
   const { timeLeft, formatTime } = useEcosTimer(900);
+
+  const printableScenario = useMemo<EcosPrintableScenario>(() => ({
+    id: scenarioData.id,
+    itemSlug: scenarioData.itemSlug ?? scenarioParam ?? scenarioData.id,
+    title: scenarioData.title,
+    specialty: scenarioData.specialty,
+    duration: scenarioData.duration,
+    pitch: scenarioData.pitch,
+    patient: scenarioData.patient,
+    steps: scenarioData.steps,
+  }), [scenarioParam]);
+
+  const computedSlug = useMemo(() => {
+    const rawSlug = printableScenario.itemSlug ?? scenarioParam ?? scenarioData.id;
+
+    if (!rawSlug) {
+      return 'ecos-item';
+    }
+
+    const normalized = rawSlug
+      .toString()
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+
+    return normalized || 'ecos-item';
+  }, [printableScenario.itemSlug, scenarioParam]);
+
+  const itemPath = `/edn-production/${computedSlug}`;
+  const itemUrl = typeof window !== 'undefined'
+    ? new URL(itemPath, window.location.origin).toString()
+    : itemPath;
+
+  const { exportPdf, printState, isGenerating } = useEcosPdfExport({
+    scenario: printableScenario,
+    itemUrl,
+  });
 
   const handleResponse = (field: string, value: string) => {
     setResponses(prev => ({...prev, [field]: value}));
@@ -37,19 +78,22 @@ const EcosScenario = () => {
   };
 
   return (
-    <ConsistentBackground variant="primary">
-      <PageHeader 
-        title="Simulation ECOS" 
-        subtitle="Examen Clinique Objectif Structuré" 
-        backTo="/ecos" 
+    <>
+      <ConsistentBackground variant="primary">
+      <PageHeader
+        title="Simulation ECOS"
+        subtitle="Examen Clinique Objectif Structuré"
+        backTo="/ecos"
       />
       
       <div className="container mx-auto px-4 py-8">
-        <EcosHeader 
+        <EcosHeader
           timeLeft={timeLeft}
           formatTime={formatTime}
           scenarioId={scenarioData.id}
           specialty={scenarioData.specialty}
+          onExportPdf={exportPdf}
+          isExporting={isGenerating}
         />
 
         {/* Scenario header */}
@@ -84,7 +128,13 @@ const EcosScenario = () => {
           />
         )}
       </div>
-    </ConsistentBackground>
+      </ConsistentBackground>
+      <EcosPdfTemplate
+        scenario={printableScenario}
+        printState={printState}
+        itemUrl={itemUrl}
+      />
+    </>
   );
 };
 

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,113 @@
+.ecos-print-root {
+  display: none;
+}
+
+@media print {
+  @page {
+    size: A4 portrait;
+    margin: 15mm;
+  }
+
+  body.ecos-printing {
+    margin: 0;
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+    background: #ffffff;
+  }
+
+  body.ecos-printing * {
+    visibility: hidden;
+  }
+
+  body.ecos-printing .ecos-print-root,
+  body.ecos-printing .ecos-print-root * {
+    visibility: visible;
+  }
+
+  body.ecos-printing .ecos-print-root {
+    position: absolute;
+    inset: 0;
+    display: block !important;
+    padding: 12mm;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: #0f172a;
+    background: #ffffff;
+    line-height: 1.35;
+  }
+
+  body.ecos-printing .ecos-print-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
+    align-items: start;
+    margin-bottom: 12mm;
+    border-bottom: 1px solid #e2e8f0;
+    padding-bottom: 8mm;
+  }
+
+  body.ecos-printing .ecos-print-title {
+    font-size: 24px;
+    font-weight: 700;
+    color: #0f172a;
+    margin: 0 0 4mm 0;
+  }
+
+  body.ecos-printing .ecos-print-subtitle {
+    font-size: 15px;
+    font-weight: 500;
+    color: #334155;
+    margin: 0;
+  }
+
+  body.ecos-printing .ecos-print-meta {
+    font-size: 11px;
+    color: #475569;
+    margin: 0;
+  }
+
+  body.ecos-printing .ecos-print-section {
+    margin-bottom: 10mm;
+    page-break-inside: avoid;
+  }
+
+  body.ecos-printing .ecos-print-section h2 {
+    font-size: 17px;
+    font-weight: 600;
+    color: #0f172a;
+    margin-bottom: 4mm;
+  }
+
+  body.ecos-printing .ecos-print-section ul,
+  body.ecos-printing .ecos-print-section ol {
+    margin: 0;
+    padding-left: 5mm;
+    font-size: 13px;
+    color: #1e293b;
+  }
+
+  body.ecos-printing .ecos-print-tag {
+    display: inline-block;
+    padding: 2mm 4mm;
+    margin: 0 3mm 3mm 0;
+    border-radius: 6mm;
+    font-size: 11px;
+    font-weight: 600;
+    background: #ecfdf5;
+    color: #047857;
+  }
+
+  body.ecos-printing .ecos-print-qr {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3mm;
+    padding: 6mm;
+    border: 1px solid #e2e8f0;
+    border-radius: 6mm;
+  }
+
+  body.ecos-printing .ecos-print-qr img {
+    width: 38mm;
+    height: 38mm;
+  }
+}


### PR DESCRIPTION
## Summary
- add QR code generation support and print-specific styles for ECOS exports
- create reusable ECOS PDF template and hook to drive QR-enabled printing
- expose an Export PDF action on the ECOS scenario screen wired to the new print flow

## Testing
- npm run lint *(fails: existing Prettier violations across legacy test files)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2ce3480d8832db9ade88c366db19f