### PR TITLE
Fix invalid package.json formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lighthouse:ci": "node scripts/run-lighthouse-ci.mjs",
     "sitemap:generate": "node scripts/generate-sitemap.mjs",
     "pm:setup-backlog": "node scripts/github/setup-backlog.mjs",
-    "prebuild": "npm run generate:sitemap"
+    "prebuild": "npm run sitemap:generate"
   },
   "dependencies": {
     "@11labs/react": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "prebuild": "npm run sitemap:generate",
     "postbuild": "node scripts/generateItemPages.mjs",
-    "prebuild": "node scripts/generateSitemap.mjs",
     "seo:generate": "node scripts/generateSitemap.mjs",
     "build:dev": "vite build --mode development",
     "lint": "eslint src/index.ts src/controllers src/services src/middleware test eslint.config.js",
@@ -27,8 +25,8 @@
     "audit": "node scripts/run-audit.js",
     "postdeploy:check": "node scripts/postdeployIntegrityCheck.mjs",
     "lighthouse:ci": "node scripts/run-lighthouse-ci.mjs",
-    "sitemap:generate": "node scripts/generate-sitemap.mjs"
-    "pm:setup-backlog": "node scripts/github/setup-backlog.mjs"
+    "sitemap:generate": "node scripts/generate-sitemap.mjs",
+    "pm:setup-backlog": "node scripts/github/setup-backlog.mjs",
     "prebuild": "npm run generate:sitemap"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- clean up duplicated prebuild entries in package.json scripts and restore valid JSON formatting
- ensure supporting sitemap scripts remain available without syntax errors

## Testing
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"


------
https://chatgpt.com/codex/tasks/task_e_68d4e48bb6b4832d822e2b613e03caa2